### PR TITLE
Add handling for secrets in `.npmrc` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 !.dockerignore
 .python-version
 .vscode
+.idea

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -130,13 +130,13 @@ class BasePlugin:
         potential_secrets = {}
         file_lines = tuple(file.readlines())
         for line_num, line in enumerate(file_lines, start=1):
-            results = self.analyze_line(line, line_num, filename, output_raw)
-            if (
-                not results
-                or
-                self._is_excluded_line(line)
-            ):
+            if self._is_excluded_line(line):
                 continue
+
+            results = self.analyze_line(line, line_num, filename, output_raw)
+            if not results:
+                continue
+
             if not self.should_verify:
                 potential_secrets.update(results)
                 continue

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -130,7 +130,6 @@ class BasePlugin:
         potential_secrets = {}
         file_lines = tuple(file.readlines())
         for line_num, line in enumerate(file_lines, start=1):
-            # TODO Put the file pre-processor here?
             results = self.analyze_line(line, line_num, filename, output_raw)
             if (
                 not results

--- a/test_data/.npmrc
+++ b/test_data/.npmrc
@@ -1,0 +1,13 @@
+# Default registry settings, which uses _auth to encode username:password.
+registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-virtual
+_auth = aWJtZXJAaWJtLmNvbTpBS0NhYmNkZWZnaGlqa2xtbm9wcXJzdHV2eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5bm90cmVhbG9r
+always-auth = true
+email = ibmer@ibm.com
+
+# Scope-specific registry settings, which uses _password to encode a password.
+# Note: The API key used here is slightly different, so that it'll be detected separately.
+@taas:registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-local/
+//na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-local/:_password=QUtDYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnh5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMDEyMzQ1Njc4OW5vdHJlYWxseQ==
+//na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-local/:username=ibmer@ibm.com
+//na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-local/:email=ibmer@ibm.com
+//na.artifactory.swg-devops.com/artifactory/api/npm/wcp-taas-team-example-npm-local/:always-auth=true


### PR DESCRIPTION
This PR (as [discussed between TaaS and Toolbox](https://ibm-cloud.slack.com/archives/CR9LSKVUK/p1614876504014400)), adds logic to decode base64 values in the `_auth` and `_password` keys of `.npmrc` files.

The logic is baked directly into the `analyze_line` function within `base.py`, but could be externalized into a plugin system if other, similar pre-processors are needed.

If a filename ends in `.npmrc`, then the logic is applied independently for every line and every plugin. (This is required by the underlying architecture, since the file text isn't stored in memory between plugins.) However, the logic is skipped whenever the plugin has already found a result in the raw text. For example, the high-entropy scanners will return results immediately, rather than attempt to decode the line.

The PR also adds tests specifically for the Artifactory plugin, which was the impetus for this PR in the first place. But I'd be happy to add additional tests if requested.