### PR TITLE
Login to GH and GHE to fix deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         #   python: pypy
 before_install:
     - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
-    - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub enterprise
+    - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub Enterprise
 install:
     - pip install tox
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: python
 
 git:
-  depth: false
+    depth: false
 services:
     - docker
 deploy:
-- provider: script
-  script: >-
-        set -e; make docker-build-images docker-test-images setup-trivy docker-quality-images deploy
-  on:
-    all_branches: true
-    # only build docker image and push once
-    condition: $TOXENV = py38
-    # only deploy when pushing to gh repo
-    repo: IBM/detect-secrets
+    - provider: script
+      script: >-
+          set -e; make docker-build-images docker-test-images setup-trivy docker-quality-images deploy
+      on:
+          all_branches: true
+          # only build docker image and push once
+          condition: $TOXENV = py38
+          # only deploy when pushing to gh repo
+          repo: IBM/detect-secrets
 
 matrix:
     include:
@@ -23,12 +23,15 @@ matrix:
           python: 3.6.10 # We're targeting a specific patch version; if set to 3.6, the GitHub Travis build will use Python 3.6.7 and will fail due to a cryptography installation error
         - env: TOXENV=py37
           python: 3.7
-          dist: xenial  # Required for Python >= 3.7 (travis-ci/travis-ci#9069)
+          dist: xenial # Required for Python >= 3.7 (travis-ci/travis-ci#9069)
         - env: TOXENV=py38
           python: 3.8
-          dist: xenial  # Required for Python >= 3.7 (travis-ci/travis-ci#9069)
+          dist: xenial # Required for Python >= 3.7 (travis-ci/travis-ci#9069)
         # - env: TOXENV=pypy
         #   python: pypy
+before_install:
+    - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
+    - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub enterprise
 install:
     - pip install tox
 script: make test


### PR DESCRIPTION
## Description
This PR fixes the Travis CI deployment by logging into GH + GHE using personal access tokens since public repos cannot use SSH keys in Travis. See https://stackoverflow.com/a/51092120 and https://docs.travis-ci.com/user/private-dependencies#api-token for more details.

[Travis build logs](https://app.travis-ci.com/github/IBM/detect-secrets/jobs/531767561):
```
git fetch origin --tag

# Once a new tag is generated, it will trigger Travis to publish new image

TAG_VERSION=$(git describe --tags --abbrev=0); \

NEW_VERSION=$(grep VERSION detect_secrets/__init__.py | cut -d\' -f2 ); \

if [ $TAG_VERSION != $NEW_VERSION ]; then \

	git tag $NEW_VERSION 6622c0d2ddf3e6663ccc97fac41b691a972fcf4e; \

	git push origin --tags; \

fi

remote: Invalid username or password.

fatal: Authentication failed for 'https://github.com/IBM/detect-secrets.git/'

Makefile.ibm:106: recipe for target 'release' failed

make[1]: *** [release] Error 128

make[1]: Leaving directory '/home/travis/build/IBM/detect-secrets'

Makefile.ibm:117: recipe for target 'deploy' failed

make: *** [deploy] Error 2
```