### PR TITLE
Fix GHE host authenticity issue with Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ git:
     depth: false
 services:
     - docker
+addons:
+  ssh_known_hosts: github.ibm.com
 deploy:
     - provider: script
       script: >-
@@ -14,7 +16,6 @@ deploy:
           condition: $TOXENV = py38
           # only deploy when pushing to gh repo
           repo: IBM/detect-secrets
-
 matrix:
     include:
         # - env: TOXENV=py35


### PR DESCRIPTION
See https://docs.travis-ci.com/user/ssh-known-hosts/

Fixes
```
git fetch github

The authenticity of host 'github.ibm.com (169.60.70.162)' can't be established.

...

Are you sure you want to continue connecting (yes/no)? 

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```