### PR TITLE
porting square oauth detector from yelp's upstream

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -493,6 +493,12 @@ class PluginOptions:
             help_text='Disables scans for NPM keys.',
             filename='npm',
         ),
+        PluginDescriptor(
+            classname='SquareOAuthDetector',
+            flag_text='--no-square-oauth',
+            help_text='Disables scans for Square OAuth tokens.',
+            filename='square_oauth',
+        ),
     ]
     opt_in_plugins = [
         PluginDescriptor(

--- a/detect_secrets/plugins/square_oauth.py
+++ b/detect_secrets/plugins/square_oauth.py
@@ -1,0 +1,12 @@
+import re
+
+from detect_secrets.plugins.base import RegexBasedDetector
+
+
+class SquareOAuthDetector(RegexBasedDetector):
+    """Scans for Square OAuth Secrets"""
+    secret_type = 'Square OAuth Secret'
+
+    denylist = [
+        re.compile(r'sq0csp-[0-9A-Za-z\\\-_]{43}'),
+    ]

--- a/tests/plugins/square_oauth_test.py
+++ b/tests/plugins/square_oauth_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from detect_secrets.plugins.square_oauth import SquareOAuthDetector
+
+
+class TestSquareOauthDetector:
+
+    @pytest.mark.parametrize(
+        'payload',
+        (
+            'square_oauth = sq0csp-ABCDEFGHIJK_LMNOPQRSTUVWXYZ-0123456789\\abcd',
+        ),
+    )
+    def test_analyze(self, payload):
+        logic = SquareOAuthDetector()
+        assert logic.analyze_line(payload, 1, 'mock_filename')


### PR DESCRIPTION
Ports the Square OAuth Detector from Yelp's upstream with a few small changes to tests to make it work with IBM's fork.