### PR TITLE
port new regex for AWS from Yelp's upstream

### DIFF
--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -21,6 +21,10 @@ class AWSKeyDetector(RegexBasedDetector):
 
     denylist = (
         re.compile(r'AKIA[0-9A-Z]{16}'),
+        # This examines the variable name to identify AWS secret tokens.
+        # The order is important since we want to prefer finding `AKIA`-based
+        # keys (since they can be verified), rather than the secret tokens.
+        re.compile(r'aws.{0,20}?[\'\"]([0-9a-zA-Z/+]{40})[\'\"]'),
     )
 
     @classproperty
@@ -28,6 +32,11 @@ class AWSKeyDetector(RegexBasedDetector):
         return 'no-aws-scan'
 
     def verify(self, token, content, potential_secret=None):
+        # As this verification process looks for multi-factor secrets, by assuming that
+        # the identified secret token is the key ID (then looking for the corresponding secret).
+        # we quit early if it fails our assumptions.
+        if not self.denylist[0].match(token):
+            return VerifiedResult.UNVERIFIED
         secret_access_key = get_secret_access_keys(content)
         if not secret_access_key:
             return VerifiedResult.UNVERIFIED

--- a/tests/plugins/aws_key_test.py
+++ b/tests/plugins/aws_key_test.py
@@ -34,6 +34,18 @@ class TestAWSKeyDetector(object):
                 'AKIAZZZ',
                 False,
             ),
+            (
+                'aws_access_key = "{}"'.format(EXAMPLE_SECRET),
+                True,
+            ),
+            (
+                'aws_access_key = "{}"'.format(EXAMPLE_SECRET + 'a'),
+                False,
+            ),
+            (
+                'aws_access_key = "{}"'.format(EXAMPLE_SECRET[0:39]),
+                False,
+            ),
         ],
     )
     def test_analyze(self, file_content, should_flag):
@@ -49,6 +61,7 @@ class TestAWSKeyDetector(object):
         logic = AWSKeyDetector()
 
         assert logic.verify(self.example_key, '') == VerifiedResult.UNVERIFIED
+        assert logic.verify(EXAMPLE_SECRET, '') == VerifiedResult.UNVERIFIED
 
     def test_verify_valid_secret(self):
         with mock.patch(


### PR DESCRIPTION
Brings in the new AWS regex from Yelp's upstream