### PR TITLE
Adding github token detector from yelp's upstream

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -457,8 +457,8 @@ class PluginOptions:
         PluginDescriptor(
             classname='GheDetector',
             flag_text='--no-ghe-scan',
-            help_text='Disables scans for GitHub credentials',
-            filename='gh',
+            help_text='Disables scans for GitHub Enterprise credentials',
+            filename='github_enterprise',
             related_args=[
                 ('--ghe-instance', DEFAULT_GHE_INSTANCE),
             ],
@@ -504,6 +504,12 @@ class PluginOptions:
             flag_text='--no-azure-storage-scan',
             help_text='Disables scans for Azure Storage Account access.',
             filename='azure_storage_key',
+        ),
+        PluginDescriptor(
+            classname='GitHubTokenDetector',
+            flag_text='--no-github-scan',
+            help_text='Disables scans for GitHub credentials',
+            filename='github_token',
         ),
     ]
     opt_in_plugins = [

--- a/detect_secrets/plugins/github_enterprise.py
+++ b/detect_secrets/plugins/github_enterprise.py
@@ -8,9 +8,9 @@ from detect_secrets.core.constants import VerifiedResult
 
 
 class GheDetector(RegexBasedDetector):
-    """ Scans for GitHub credentials """
+    """ Scans for GitHub Enterprise credentials """
 
-    secret_type = 'GitHub Credentials'
+    secret_type = 'GitHub Enterprise Credentials'
     denylist = None
 
     def __init__(self, ghe_instance=DEFAULT_GHE_INSTANCE, *args, **kwargs):

--- a/detect_secrets/plugins/github_token.py
+++ b/detect_secrets/plugins/github_token.py
@@ -1,0 +1,16 @@
+"""
+This plugin searches for GitHub tokens
+"""
+import re
+
+from detect_secrets.plugins.base import RegexBasedDetector
+
+
+class GitHubTokenDetector(RegexBasedDetector):
+    """Scans for GitHub tokens."""
+    secret_type = 'GitHub Token'
+
+    denylist = [
+        # ref. https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+        re.compile(r'(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}'),
+    ]

--- a/tests/plugins/gh_enterprise_test.py
+++ b/tests/plugins/gh_enterprise_test.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 
 from detect_secrets.core.constants import VerifiedResult
-from detect_secrets.plugins.gh import GheDetector
+from detect_secrets.plugins.github_enterprise import GheDetector
 
 
 GHE_TOKEN = 'abcdef0123456789abcdef0123456789abcdef01'

--- a/tests/plugins/github_token_test.py
+++ b/tests/plugins/github_token_test.py
@@ -1,0 +1,19 @@
+import pytest
+
+from detect_secrets.plugins.github_token import GitHubTokenDetector
+
+
+class TestGitHubTokenDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('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', True),
+            ('foo_wWPw5k4aXcaT4fNP0UcnZwJUVFk6LO0pINUx', False),
+            ('foo', False),
+        ],
+    )
+    def test_analyze(self, payload, should_flag):
+        logic = GitHubTokenDetector()
+        output = logic.analyze_line(payload, 1, 'mock_filename')
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
Changes:
- Adding github token detector from yelp's upstream
  - Plugin: https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/github_token.py
  - Tests: https://github.com/Yelp/detect-secrets/blob/master/tests/plugins/github_token_test.py
- Updated previous GHE plugin to be more specific that its a Github Enterprise credential 
  - Renamed file from `gh` to `github_enterprise`
  - Update help text 
  - Updated secret_type