### PR TITLE
Remove Pyup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = true
 # tox_pip_extensions_ext_venv_update = true
 
 [testenv]
-passenv = SSH_AUTH_SOCK SAFETY_API_KEY
+passenv = SSH_AUTH_SOCK
 deps = -rrequirements-dev.txt
 whitelist_externals = coverage
 commands =


### PR DESCRIPTION
We are using dependabot now. Once this is verified and merged, we should also remove `SAFETY_API_KEY` (the Pyup API key) from Travis.