### PR TITLE
Windows native: always use forward-slash path separators

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import types
 
 from detect_secrets import util
@@ -76,12 +77,14 @@ def initialize(
 
     if exclude_files_regex:
         exclude_files_regex = re.compile(exclude_files_regex, re.IGNORECASE)
-        files_to_scan = filter(
-            lambda file: (
-                not exclude_files_regex.search(file)
-            ),
-            files_to_scan,
-        )
+
+        def filename_regex_match(filename):
+            if sys.platform.lower() == 'win32':
+                # use Unix-like forward-slash path separator when filtering, for cross-platform compatibility
+                filename = filename.replace('\\', '/')
+            return not exclude_files_regex.search(filename)
+
+        files_to_scan = filter(filename_regex_match, files_to_scan)
 
     for file in sorted(files_to_scan):
         output.scan_file(file)

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -80,7 +80,8 @@ def initialize(
 
         def filename_regex_match(filename):
             if sys.platform.lower() == 'win32':
-                # use Unix-like forward-slash path separator when filtering, for cross-platform compatibility
+                # use Unix-like forward-slash path separator when filtering
+                # for cross-platform compatibility
                 filename = filename.replace('\\', '/')
             return not exclude_files_regex.search(filename)
 

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -2,6 +2,7 @@ import codecs
 import json
 import os
 import re
+import sys
 from time import gmtime
 from time import strftime
 
@@ -334,6 +335,10 @@ class SecretsCollection:
 
         if not file_results:
             return
+
+        if sys.platform.lower() == 'win32':
+            # always store results with Unix-like forward-slashes, for cross-platform compatibility
+            filename = filename.replace('\\', '/')
 
         if filename not in self.data:
             self.data[filename] = file_results


### PR DESCRIPTION
When running on Windows natively, write baseline files using forward-slash path separators, for cross-platform compatibility.

Without this, entries created from other platforms can be mismatched by `detect secrets audit`, and it becomes impossible to pass the pre-commit check.

After:
```
$ detect-secrets scan
{
  // ... snipped ...
  ],
  "results": {
    "docs/_how-to/API-keys.md": [
      {
        "hashed_secret": "bf10dae7b89461df3fd3c48f86ec23543710e8cd",
        "is_verified": false,
        "line_number": 194,
        "type": "Secret Keyword",
        "verified_result": null
      },
```


Before:
```
$ detect-secrets scan
{
  // ... snipped ...
  ],
  "results": {
    "docs\\_how-to\\API-keys.md": [
      {
        "hashed_secret": "bf10dae7b89461df3fd3c48f86ec23543710e8cd",
        "is_verified": false,
        "line_number": 194,
        "type": "Secret Keyword",
        "verified_result": null
      },
```

Apologies for the lack of tests, I'm not normally a Python dev, and don't have a dev environment setup right now. If it's essential, I'll try and find the time later to extend this PR. Or as the change is quite limited, if it's OK in principal perhaps someone could help?