### PR TITLE
Add table of contents to audit documentation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-23T15:38:23Z",
+  "generated_at": "2021-12-23T15:47:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -144,7 +144,7 @@
         "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 65,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-23T15:29:38Z",
+  "generated_at": "2021-12-23T15:38:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -144,7 +144,7 @@
         "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 66,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-23T15:47:49Z",
+  "generated_at": "2021-12-23T16:44:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -144,7 +144,7 @@
         "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 68,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -15,7 +15,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## What is it?
+## What Is It?
 
 The `audit` command is a set of functionality designed for analysts to do more with
 a pre-generated baseline. Some common use cases of this include:

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,18 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
--   [Audit](#audit)
-    -   [How to Audit a Baseline](#how-to-audit-a-baseline)
-        -   [Windows Powershell and cmd](#windows-powershell-and-cmd)
-        -   [Windows git bash](#windows-git-bash)
-        -   [MacOS & Linux](#macos--linux)
-    -   [Manually Labelling Secrets](#manually-labelling-secrets)
-        -   [Handling Developer Secrets](#handling-developer-secrets)
-    -   [What to do after marking an potential secret as a valid secret?](#what-to-do-after-marking-an-potential-secret-as-a-valid-secret)
-    -   [Comparing Baselines](#comparing-baselines)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Audit
 
 The `audit` command is a set of functionality designed for analysts to do more with
@@ -20,6 +5,20 @@ a pre-generated baseline. Some common use cases of this include:
 
 -   **Manually labelling secrets**, to distinguish between true and false positives
 -   **Comparing baselines**, to determine the effect of a certain configuration
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [How to Audit a Baseline](#how-to-audit-a-baseline)
+    -   [Windows Powershell and cmd](#windows-powershell-and-cmd)
+    -   [Windows git bash](#windows-git-bash)
+    -   [MacOS & Linux](#macos--linux)
+-   [Manually Labelling Secrets](#manually-labelling-secrets)
+    -   [Handling Developer Secrets](#handling-developer-secrets)
+-   [What to do after marking an potential secret as a valid secret?](#what-to-do-after-marking-an-potential-secret-as-a-valid-secret)
+-   [Comparing Baselines](#comparing-baselines)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## How to Audit a Baseline
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,14 +1,9 @@
 # Audit
 
-The `audit` command is a set of functionality designed for analysts to do more with
-a pre-generated baseline. Some common use cases of this include:
-
--   **Manually labelling secrets**, to distinguish between true and false positives
--   **Comparing baselines**, to determine the effect of a certain configuration
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+-   [What is it?](#what-is-it)
 -   [How to Audit a Baseline](#how-to-audit-a-baseline)
     -   [Windows Powershell and cmd](#windows-powershell-and-cmd)
     -   [Windows git bash](#windows-git-bash)
@@ -19,6 +14,14 @@ a pre-generated baseline. Some common use cases of this include:
 -   [Comparing Baselines](#comparing-baselines)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## What is it?
+
+The `audit` command is a set of functionality designed for analysts to do more with
+a pre-generated baseline. Some common use cases of this include:
+
+-   **Manually labelling secrets**, to distinguish between true and false positives
+-   **Comparing baselines**, to determine the effect of a certain configuration
 
 ## How to Audit a Baseline
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [Audit](#audit)
+    -   [How to Audit a Baseline](#how-to-audit-a-baseline)
+        -   [Windows Powershell and cmd](#windows-powershell-and-cmd)
+        -   [Windows git bash](#windows-git-bash)
+        -   [MacOS & Linux](#macos--linux)
+    -   [Manually Labelling Secrets](#manually-labelling-secrets)
+        -   [Handling Developer Secrets](#handling-developer-secrets)
+    -   [What to do after marking an potential secret as a valid secret?](#what-to-do-after-marking-an-potential-secret-as-a-valid-secret)
+    -   [Comparing Baselines](#comparing-baselines)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Audit
 
 The `audit` command is a set of functionality designed for analysts to do more with
@@ -16,7 +31,7 @@ $ detect-secrets audit .secrets.baseline
 
 ### Windows Powershell and cmd
 
-> Note: You can also setup a Powershell script following [doc here](https://github.com/IBM/detect-secrets/blob/master/docs/developer-tool-faq.md#powershell-docker-command-is-too-long-do-you-have-some-shortcut-for-detect-secrets) to avoid typing the long command.
+> Note: You can also setup a Powershell script following [doc here](./developer-tool-faq.md#powershell-docker-command-is-too-long-do-you-have-some-shortcut-for-detect-secrets) to avoid typing the long command.
 
 ```shell
 docker run -it --rm -v c:/replace/with/your/folder/containing/git/repo:/code ibmcom/detect-secrets:latest audit .secrets.baseline

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -3,7 +3,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
--   [What is it?](#what-is-it)
+-   [What Is It?](#what-is-it)
 -   [How to Audit a Baseline](#how-to-audit-a-baseline)
     -   [Windows Powershell and cmd](#windows-powershell-and-cmd)
     -   [Windows git bash](#windows-git-bash)


### PR DESCRIPTION
Changes to audit documentation:
- Add table of contents
- Update link to use relative path instead of absolute path 