### PR TITLE
resolving IBM Cloud IAM test test_verify_payload_not_json

### DIFF
--- a/tests/plugins/ibm_cloud_iam_test.py
+++ b/tests/plugins/ibm_cloud_iam_test.py
@@ -130,5 +130,4 @@ class TestIbmCloudIamDetector(object):
             body='not json', headers={'content-type': 'not/json'},
         )
 
-        with pytest.raises(Exception):
-            IbmCloudIamDetector().verify(CLOUD_IAM_KEY)
+        assert IbmCloudIamDetector().verify(CLOUD_IAM_KEY) == VerifiedResult.UNVERIFIED


### PR DESCRIPTION
With the latest requests package version 2.27.0 made the following change:

```
  - Added a `requests.exceptions.JSONDecodeError` to unify JSON exceptions between
  Python 2 and 3. This gets raised in the `response.json()` method, and is
  backwards compatible as it inherits from previously thrown exceptions.
  Can be caught from `requests.exceptions.RequestException` as well. (5856)
```
See https://pyup.io/changelogs/requests/ for more changes

Because of this we are swallowing the `RequestException` and returning `VerifiedResult.UNVERIFIED`. See https://github.com/IBM/detect-secrets/blob/master/detect_secrets/plugins/ibm_cloud_iam.py#L40

Changes: 
- Fixing IBM Cloud IAM test: test_verify_payload_not_json 