### PR TITLE
Add usage for reporting functionality

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -64,8 +64,8 @@ class ParserBuilder(object):
         self._add_filenames_argument()\
             ._add_set_baseline_argument()\
             ._add_exclude_lines_argument()\
-            ._add_word_list_argument().\
-            _add_use_all_plugins_argument()\
+            ._add_word_list_argument()\
+            ._add_use_all_plugins_argument()\
             ._add_no_verify_flag()\
             ._add_output_verified_false_flag()\
             ._add_fail_on_non_audited_flag()

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -68,7 +68,7 @@ class ParserBuilder(object):
             _add_use_all_plugins_argument()\
             ._add_no_verify_flag()\
             ._add_output_verified_false_flag()\
-            ._add_fail_on_unaudited_flag()
+            ._add_fail_on_non_audited_flag()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -145,9 +145,9 @@ class ParserBuilder(object):
         add_output_verified_false_flag(self.parser)
         return self
 
-    def _add_fail_on_unaudited_flag(self):
+    def _add_fail_on_non_audited_flag(self):
         self.parser.add_argument(
-            '--fail-on-unaudited',
+            '--fail-on-non-audited',
             action='store_true',
             help='Fail check if there are entries have not been audited in baseline.',
         )

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -273,9 +273,9 @@ class AuditOptions:
             action='store_true',
             help=(
                 'This condition is met when there are potential secrets'
-                ' in the baseline file which have not been audited yet.'
-                ' To pass this check, run detect-secrets audit .secrets.baseline to'
-                ' audit any unaudited secrets.'
+                ' in the baseline file which have not yet been audited.'
+                ' To pass this check, run detect-secrets audit <BASELINE_FILE> to'
+                ' audit all unaudited secrets.'
             ),
         )
 
@@ -296,9 +296,9 @@ class AuditOptions:
             help=(
                 'This condition is met when the baseline file contains'
                 ' one or more secrets which have been marked as actual'
-                ' secrets during the auditing stage. Secrets with a'
+                ' secrets during the auditing process. Secrets with a'
                 ' property of is_secret: true meet this condition.'
-                ' To pass this check, remove those secrets from your'
+                ' To pass this check, remove these secrets from your'
                 ' code and re-scan so that they will be removed from your baseline.'
             ),
         )
@@ -307,13 +307,13 @@ class AuditOptions:
         report_parser_exclusive.add_argument(
             '--json',
             action='store_true',
-            help=('Providing this flag will cause the report output to be formatted as JSON.'),
+            help=('Causes the report output to be formatted as JSON.'),
         )
 
         report_parser_exclusive.add_argument(
             '--omit-instructions',
             action='store_true',
-            help=('Providing this flag will omit instructions from the report.'),
+            help=('Omits instructions from the report.'),
         )
 
     def add_arguments(self):

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -51,37 +51,36 @@ def add_output_verified_false_flag(parser):
 
 
 class ParserBuilder(object):
-
     def __init__(self):
         self.parser = argparse.ArgumentParser()
+        self.subparser = None
 
         self.add_default_arguments()
 
     def add_default_arguments(self):
-        self._add_verbosity_argument()\
-            ._add_version_argument()
+        self._add_verbosity_argument()._add_version_argument()
 
     def add_pre_commit_arguments(self):
         self._add_filenames_argument()\
             ._add_set_baseline_argument()\
             ._add_exclude_lines_argument()\
-            ._add_word_list_argument()\
-            ._add_use_all_plugins_argument()\
-            ._add_no_verify_flag() \
+            ._add_word_list_argument().\
+            _add_use_all_plugins_argument()\
+            ._add_no_verify_flag()\
             ._add_output_verified_false_flag()\
-            ._add_fail_on_non_audited_flag()
+            ._add_fail_on_unaudited_flag()
 
         PluginOptions(self.parser).add_arguments()
 
         return self
 
     def add_console_use_arguments(self):
-        subparser = self.parser.add_subparsers(
+        self.subparser = self.parser.add_subparsers(
             dest='action',
         )
 
         for action_parser in (ScanOptions, AuditOptions):
-            action_parser(subparser).add_arguments()
+            action_parser(self.subparser).add_arguments()
 
         return self
 
@@ -146,9 +145,9 @@ class ParserBuilder(object):
         add_output_verified_false_flag(self.parser)
         return self
 
-    def _add_fail_on_non_audited_flag(self):
+    def _add_fail_on_unaudited_flag(self):
         self.parser.add_argument(
-            '--fail-on-non-audited',
+            '--fail-on-unaudited',
             action='store_true',
             help='Fail check if there are entries have not been audited in baseline.',
         )
@@ -156,9 +155,8 @@ class ParserBuilder(object):
 
 
 class ScanOptions:
-
     def __init__(self, subparser):
-        self.parser = subparser.add_parser(
+        self.parser: argparse.ArgumentParser = subparser.add_parser(
             'scan',
         )
 
@@ -229,10 +227,7 @@ class ScanOptions:
             '--string',
             nargs='?',
             const=True,
-            help=(
-                'Scans an individual string, and displays configured '
-                'plugins\' verdict.'
-            ),
+            help=('Scans an individual string, and displays configured ' 'plugins\' verdict.'),
         )
         return self
 
@@ -250,10 +245,75 @@ class ScanOptions:
 
 
 class AuditOptions:
-
     def __init__(self, subparser):
-        self.parser = subparser.add_parser(
+        # Override the default audit parser usage message since the arguments within
+        # the _add_report_module group should only be permitted when the --report
+        # arg is included. argparse does not have built-in mutual inclusion functionality,
+        # so we had to add our own custom validation function, validate_args,
+        # in detect-secrets/core/report/report.py.
+        # docs: https://docs.python.org/3/library/argparse.html#usage
+        self.parser: argparse.ArgumentParser = subparser.add_parser(
             'audit',
+            usage='%(prog)s [-h] [--diff |  --display-results | --report [--fail-on-unaudited]'
+            """ [--fail-on-live] [--fail-on-audited-real] [--json | --omit-instructions]]
+                     filename [filename ...]""",
+        )
+
+    def _add_report_module(self):
+        report_parser = self.parser.add_argument_group(
+            title='reporting',
+            description=(
+                'Displays a report with the secrets detected which fail certain conditions. '
+                'To be used with the report mode (--report).'
+            ),
+        )
+
+        report_parser.add_argument(
+            '--fail-on-unaudited',
+            action='store_true',
+            help=(
+                'This condition is met when there are potential secrets'
+                ' in the baseline file which have not been audited yet.'
+                ' To pass this check, run detect-secrets audit .secrets.baseline to'
+                ' audit any unaudited secrets.'
+            ),
+        )
+
+        report_parser.add_argument(
+            '--fail-on-live',
+            action='store_true',
+            help=(
+                'This condition is met when a secret has been verified'
+                ' to be live. To pass this check, make sure that any'
+                ' secrets in the baseline file with a property of'
+                ' is_verified: true have been remediated, afterwards re-scan.'
+            ),
+        )
+
+        report_parser.add_argument(
+            '--fail-on-audited-real',
+            action='store_true',
+            help=(
+                'This condition is met when the baseline file contains'
+                ' one or more secrets which have been marked as actual'
+                ' secrets during the auditing stage. Secrets with a'
+                ' property of is_secret: true meet this condition.'
+                ' To pass this check, remove those secrets from your'
+                ' code and re-scan so that they will be removed from your baseline.'
+            ),
+        )
+        report_parser_exclusive = report_parser.add_mutually_exclusive_group()
+
+        report_parser_exclusive.add_argument(
+            '--json',
+            action='store_true',
+            help=('Providing this flag will cause the report output to be formatted as JSON.'),
+        )
+
+        report_parser_exclusive.add_argument(
+            '--omit-instructions',
+            action='store_true',
+            help=('Providing this flag will omit instructions from the report.'),
         )
 
     def add_arguments(self):
@@ -287,6 +347,14 @@ class AuditOptions:
             ),
         )
 
+        action_parser.add_argument(
+            '--report',
+            action='store_true',
+            help=('Displays a report with the secrets detected'),
+        )
+
+        self._add_report_module()
+
         return self
 
 
@@ -296,13 +364,10 @@ class PluginDescriptor(
         [
             # Classname of plugin; used for initialization
             'classname',
-
             # Flag to disable plugin. e.g. `--no-hex-string-scan`
             'flag_text',
-
             # Description for disable flag.
             'help_text',
-
             # type: list
             # Allows the bundling of all related command line provided
             # arguments together, under one plugin name.
@@ -315,19 +380,13 @@ class PluginDescriptor(
             # Therefore, only populate the default value upon consolidation
             # (rather than relying on argparse default).
             'related_args',
-
             # The name of the plugin file
             'filename',
         ],
     ),
 ):
-
     def __new__(cls, related_args=None, **kwargs):
-        return super(PluginDescriptor, cls).__new__(
-            cls,
-            related_args=related_args or [],
-            **kwargs
-        )
+        return super(PluginDescriptor, cls).__new__(cls, related_args=related_args or [], **kwargs)
 
     @classmethod
     def from_plugin_class(cls, plugin, name):
@@ -339,10 +398,12 @@ class PluginDescriptor(
         if plugin.default_options:
             related_args = []
             for arg_name, value in plugin.default_options.items():
-                related_args.append((
-                    '--{}'.format(arg_name.replace('_', '-')),
-                    value,
-                ))
+                related_args.append(
+                    (
+                        '--{}'.format(arg_name.replace('_', '-')),
+                        value,
+                    ),
+                )
 
         return cls(
             classname=name,
@@ -597,9 +658,11 @@ class PluginOptions:
                     related_args[arg_name] = default_value
                     is_using_default_value[arg_name] = True
 
-            active_plugins.update({
-                plugin.classname: related_args,
-            })
+            active_plugins.update(
+                {
+                    plugin.classname: related_args,
+                },
+            )
 
         for plugin in PluginOptions.all_plugins:
             if getattr(plugin, 'classname') in list(active_plugins):


### PR DESCRIPTION
## Related issue

Supports internal issue 623 in Team-backlog

## Description of changes

This is a sub-PR of https://github.com/IBM/detect-secrets/pull/46 (I'm breaking down the reporting PR for easier readability for reviewers).

- Formatted `usage.py`
- Added reporting feature arguments using [`argparse`](https://docs.python.org/3/library/argparse.html) module
- Overwrote detect-secrets audit usage string. The reason why it needs to be overwritten is because `argparse` does not support mutually inclusive args by default - example use case: `--fail-on-xx` should only be used when `--report` is included.
    - Needed to write custom validation logic for mutually-inclusive args (will open future PR for this): https://github.com/victoria-miltcheva/detect-secrets/blob/report/detect_secrets/core/report/report.py#L106-L139

## Usage help output

Command: `detect-secrets audit --help`:

```
usage: test.py audit [-h] [--diff |  --display-results | --report [--fail-on-unaudited] [--fail-on-live] [--fail-on-audited-real] [--json | --omit-instructions]]
                     filename [filename ...]

positional arguments:
  filename              Audit a given baseline file to distinguish the difference between false and true positives.

optional arguments:
  -h, --help            show this help message and exit
  --diff                Allows the comparison of two baseline files, in order to effectively distinguish the difference between various plugin
                        configurations.
  --display-results     Displays the results of an interactive auditing session which have been saved to a baseline file.
  --report              Displays a report with the secrets detected

reporting:
  Displays a report with the secrets detected which fail certain conditions. To be used with the report mode (--report).

  --fail-on-unaudited   This condition is met when there are potential secrets in the baseline file which have not yet been audited. To pass this check,
                        run detect-secrets audit <BASELINE_FILE> to audit all unaudited secrets.
  --fail-on-live        This condition is met when a secret has been verified to be live. To pass this check, make sure that any secrets in the baseline
                        file with a property of is_verified: true have been remediated, afterwards re-scan.
  --fail-on-audited-real
                        This condition is met when the baseline file contains one or more secrets which have been marked as actual secrets during the
                        auditing process. Secrets with a property of is_secret: true meet this condition. To pass this check, remove these secrets from
                        your code and re-scan so that they will be removed from your baseline.
  --json                Causes the report output to be formatted as JSON.
  --omit-instructions   Omits instructions from the report.
```