### PR TITLE
Add fail-on functions, tests, and constants for reporting module

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -336,6 +336,13 @@ def print_audit_results(baseline_filename):
     )
 
 
+def get_secrets_list_from_file(baseline_filename: str) -> list:
+    baseline = _get_baseline_from_file(baseline_filename)
+    secrets = list(_secret_generator(baseline))
+
+    return secrets
+
+
 def _get_baseline_from_file(filename):  # pragma: no cover
     try:
         with open(filename) as f:

--- a/detect_secrets/core/report/conditions.py
+++ b/detect_secrets/core/report/conditions.py
@@ -1,0 +1,89 @@
+from typing import List
+
+from detect_secrets.core.audit import get_secrets_list_from_file
+from detect_secrets.core.report.constants import ReportCheckResult
+from detect_secrets.core.report.constants import ReportedSecret
+from detect_secrets.core.report.constants import ReportExitCode
+from detect_secrets.core.report.constants import ReportSecretType
+
+
+def fail_on_unaudited(baseline_filename: str) -> ReportCheckResult:
+    """
+    Given a baseline filename, checks if that baseline contains
+    any secret results which have not been audited yet.
+
+    If so, the list of unaudited secrets is included in the return
+    value.
+    """
+    secrets = get_secrets_list_from_file(baseline_filename)
+    non_audited_secrets: List[ReportedSecret] = []
+
+    for filename, secret in secrets:
+        if 'is_secret' not in secret or secret['is_secret'] is None:
+            unaudited_secret: ReportedSecret = {
+                'failed_condition': ReportSecretType.UNAUDITED.value,
+                'filename': filename,
+                'line': secret['line_number'],
+                'type': secret['type'],
+            }
+
+            non_audited_secrets.append(unaudited_secret)
+
+    if len(non_audited_secrets) > 0:
+        return ReportCheckResult(ReportExitCode.FAIL.value, non_audited_secrets)
+
+    return ReportCheckResult(ReportExitCode.PASS.value, [])
+
+
+def fail_on_live(baseline_filename: str) -> ReportCheckResult:
+    """
+    Given a baseline filename, checks if that baseline contains
+    any active verified secrets.
+
+    If so, the list of verified secrets is included in the return
+    value.
+    """
+    secrets = get_secrets_list_from_file(baseline_filename)
+    live_secrets: List[ReportedSecret] = []
+
+    for filename, secret in secrets:
+        if 'is_verified' in secret and secret['is_verified'] is True:
+            live_secret: ReportedSecret = {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': filename,
+                'line': secret['line_number'],
+                'type': secret['type'],
+            }
+            live_secrets.append(live_secret)
+
+    if len(live_secrets) > 0:
+        return ReportCheckResult(ReportExitCode.FAIL.value, live_secrets)
+
+    return ReportCheckResult(ReportExitCode.PASS.value, [])
+
+
+def fail_on_audited_real(baseline_filename: str) -> ReportCheckResult:
+    """
+    Given a baseline filename, checks if that baseline contains
+    any secrets which have been marked as real during the auditing process.
+
+    If so, the list of audited real secrets is included in the return
+    value.
+    """
+    secrets = get_secrets_list_from_file(baseline_filename)
+    audited_true_secrets: List[ReportedSecret] = []
+
+    for filename, secret in secrets:
+        if 'is_secret' in secret and secret['is_secret'] is True:
+            audited_true_secret: ReportedSecret = {
+                'failed_condition': ReportSecretType.AUDITED_REAL.value,
+                'filename': filename,
+                'line': secret['line_number'],
+                'type': secret['type'],
+            }
+            audited_true_secrets.append(audited_true_secret)
+
+    if len(audited_true_secrets) > 0:
+        return ReportCheckResult(ReportExitCode.FAIL.value, audited_true_secrets)
+
+    return ReportCheckResult(ReportExitCode.PASS.value, [])

--- a/detect_secrets/core/report/conditions.py
+++ b/detect_secrets/core/report/conditions.py
@@ -1,8 +1,5 @@
-from typing import List
-
 from detect_secrets.core.audit import get_secrets_list_from_file
 from detect_secrets.core.report.constants import ReportCheckResult
-from detect_secrets.core.report.constants import ReportedSecret
 from detect_secrets.core.report.constants import ReportExitCode
 from detect_secrets.core.report.constants import ReportSecretType
 
@@ -16,11 +13,11 @@ def fail_on_unaudited(baseline_filename: str) -> ReportCheckResult:
     value.
     """
     secrets = get_secrets_list_from_file(baseline_filename)
-    non_audited_secrets: List[ReportedSecret] = []
+    non_audited_secrets = []
 
     for filename, secret in secrets:
         if 'is_secret' not in secret or secret['is_secret'] is None:
-            unaudited_secret: ReportedSecret = {
+            unaudited_secret = {
                 'failed_condition': ReportSecretType.UNAUDITED.value,
                 'filename': filename,
                 'line': secret['line_number'],
@@ -44,11 +41,11 @@ def fail_on_live(baseline_filename: str) -> ReportCheckResult:
     value.
     """
     secrets = get_secrets_list_from_file(baseline_filename)
-    live_secrets: List[ReportedSecret] = []
+    live_secrets = []
 
     for filename, secret in secrets:
         if 'is_verified' in secret and secret['is_verified'] is True:
-            live_secret: ReportedSecret = {
+            live_secret = {
                 'failed_condition': ReportSecretType.LIVE.value,
                 'filename': filename,
                 'line': secret['line_number'],
@@ -71,11 +68,11 @@ def fail_on_audited_real(baseline_filename: str) -> ReportCheckResult:
     value.
     """
     secrets = get_secrets_list_from_file(baseline_filename)
-    audited_true_secrets: List[ReportedSecret] = []
+    audited_true_secrets = []
 
     for filename, secret in secrets:
         if 'is_secret' in secret and secret['is_secret'] is True:
-            audited_true_secret: ReportedSecret = {
+            audited_true_secret = {
                 'failed_condition': ReportSecretType.AUDITED_REAL.value,
                 'filename': filename,
                 'line': secret['line_number'],

--- a/detect_secrets/core/report/constants.py
+++ b/detect_secrets/core/report/constants.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from typing import List
+from typing import NamedTuple
+from typing import TypedDict
+
+
+class ReportSecretType(Enum):
+    AUDITED_REAL = 'Audited as real'
+    UNAUDITED = 'Unaudited'
+    LIVE = 'Live'
+
+
+class ReportExitCode(Enum):
+    PASS = 0
+    FAIL = 1
+
+
+ReportStats = TypedDict(
+    'ReportStats',
+    {'reviewed': int, 'live': int, 'unaudited': int, 'audited_real': int},
+)
+
+ReportedSecret = TypedDict(
+    'ReportedSecret',
+    {'failed_condition': ReportSecretType, 'filename': str, 'line': int, 'type': str},
+)
+
+ReportJson = TypedDict('ReportJson', {'stats': ReportStats, 'secrets': List[ReportedSecret]})
+
+ReportCheckResult = NamedTuple(
+    'ReportCheckResult',
+    [('report_exit_code', ReportExitCode), ('secrets_failing_condition', List[ReportedSecret])],
+)

--- a/detect_secrets/core/report/constants.py
+++ b/detect_secrets/core/report/constants.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import List
 from typing import NamedTuple
-from typing import TypedDict
 
 
 class ReportSecretType(Enum):
@@ -15,19 +14,7 @@ class ReportExitCode(Enum):
     FAIL = 1
 
 
-ReportStats = TypedDict(
-    'ReportStats',
-    {'reviewed': int, 'live': int, 'unaudited': int, 'audited_real': int},
-)
-
-ReportedSecret = TypedDict(
-    'ReportedSecret',
-    {'failed_condition': ReportSecretType, 'filename': str, 'line': int, 'type': str},
-)
-
-ReportJson = TypedDict('ReportJson', {'stats': ReportStats, 'secrets': List[ReportedSecret]})
-
 ReportCheckResult = NamedTuple(
     'ReportCheckResult',
-    [('report_exit_code', ReportExitCode), ('secrets_failing_condition', List[ReportedSecret])],
+    [('report_exit_code', ReportExitCode), ('secrets_failing_condition', List)],
 )

--- a/testing/baseline.py
+++ b/testing/baseline.py
@@ -1,0 +1,31 @@
+baseline = {
+    'generated_at': 'some timestamp',
+    'plugins_used': [
+        {
+            'name': 'TestPlugin',
+        },
+    ],
+    'results': {
+        'filenameA': [
+            {
+                'hashed_secret': 'a',
+                'line_number': 122,
+                'type': 'Test Type',
+            },
+            {
+                'hashed_secret': 'b',
+                'line_number': 123,
+                'type': 'Test Type',
+            },
+        ],
+        'filenameB': [
+            {
+                'hashed_secret': 'c',
+                'line_number': 123,
+                'type': 'Test Type',
+            },
+        ],
+    },
+}
+
+baseline_filename = 'will_be_mocked'

--- a/tests/core/report/conditions_test.py
+++ b/tests/core/report/conditions_test.py
@@ -1,0 +1,242 @@
+from contextlib import contextmanager
+from copy import deepcopy
+
+import mock
+import pytest
+
+from detect_secrets.core import audit
+from detect_secrets.core.report.conditions import fail_on_audited_real
+from detect_secrets.core.report.conditions import fail_on_live
+from detect_secrets.core.report.conditions import fail_on_unaudited
+from detect_secrets.core.report.constants import ReportExitCode
+from detect_secrets.core.report.constants import ReportSecretType
+from testing.baseline import baseline
+from testing.baseline import baseline_filename
+from testing.mocks import mock_printer as mock_printer_base
+
+
+@pytest.fixture
+def mock_printer():
+    with mock_printer_base(audit) as shim:
+        yield shim
+
+
+class TestReportConditions:
+    @contextmanager
+    def mock_env(self, baseline=None):
+        if baseline is None:
+            baseline = self.baseline
+
+        with mock.patch.object(
+            # We mock this, so we don't need to do any file I/O.
+            audit,
+            '_get_baseline_from_file',
+            return_value=baseline,
+        ) as m:
+            yield m
+
+    @property
+    def baseline(self):
+        return baseline
+
+    def test_unaudited_pass_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = False
+        modified_baseline['results']['filenameA'][1]['is_secret'] = False
+        modified_baseline['results']['filenameB'][0]['is_secret'] = False
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_unaudited(baseline_filename)
+
+        assert return_code == ReportExitCode.PASS.value
+        assert len(secrets) == 0
+
+    def test_unaudited_fail_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+        modified_baseline['results']['filenameA'][1]['is_secret'] = None
+        modified_baseline['results']['filenameB'][0]['is_secret'] = None
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_unaudited(baseline_filename)
+
+        expected_secrets = [
+            {
+                'failed_condition': ReportSecretType.UNAUDITED.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.UNAUDITED.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][1]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.UNAUDITED.value,
+                'filename': 'filenameB',
+                'line': modified_baseline['results']['filenameB'][0]['line_number'],
+                'type': 'Test Type',
+            },
+        ]
+
+        assert return_code == ReportExitCode.FAIL.value
+        assert len(secrets) == len(expected_secrets)
+        assert [i for i in secrets if i not in expected_secrets] == []
+
+    def test_live_pass_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_verified'] = False
+        modified_baseline['results']['filenameA'][1]['is_verified'] = False
+        modified_baseline['results']['filenameB'][0]['is_verified'] = False
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_live(baseline_filename)
+
+        assert return_code == ReportExitCode.PASS.value
+        assert len(secrets) == 0
+
+    def test_live_fail_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_verified'] = True
+        modified_baseline['results']['filenameA'][1]['is_verified'] = True
+        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+
+        expected_secrets = [
+            {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][1]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': 'filenameB',
+                'line': modified_baseline['results']['filenameB'][0]['line_number'],
+                'type': 'Test Type',
+            },
+        ]
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_live(baseline_filename)
+
+        assert return_code == ReportExitCode.FAIL.value
+        assert len(secrets) == len(expected_secrets)
+        assert [i for i in secrets if i not in expected_secrets] == []
+
+    def test_audited_real_pass_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = False
+        modified_baseline['results']['filenameA'][1]['is_secret'] = False
+        modified_baseline['results']['filenameB'][0]['is_secret'] = False
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_audited_real(baseline_filename)
+
+        assert return_code == ReportExitCode.PASS.value
+        assert len(secrets) == 0
+
+    def test_audited_real_fail_case(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+        modified_baseline['results']['filenameA'][1]['is_secret'] = True
+        modified_baseline['results']['filenameB'][0]['is_secret'] = True
+
+        expected_secrets = [
+            {
+                'failed_condition': ReportSecretType.AUDITED_REAL.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.AUDITED_REAL.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][1]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.AUDITED_REAL.value,
+                'filename': 'filenameB',
+                'line': modified_baseline['results']['filenameB'][0]['line_number'],
+                'type': 'Test Type',
+            },
+        ]
+
+        with self.mock_env(baseline=modified_baseline):
+            (return_code, secrets) = fail_on_audited_real(baseline_filename)
+
+        assert return_code == ReportExitCode.FAIL.value
+        assert len(secrets) == len(expected_secrets)
+        assert [i for i in secrets if i not in expected_secrets] == []
+
+    def test_fail_live_and_audited_real_conditions_with_same_secret(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+        modified_baseline['results']['filenameA'][0]['is_verified'] = True
+
+        expected_secrets = [
+            {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.AUDITED_REAL.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+
+        ]
+
+        with self.mock_env(baseline=modified_baseline):
+            (live_return_code, live_secrets) = fail_on_live(baseline_filename)
+            (audited_real_return_code, audited_real_secrets) =\
+                fail_on_audited_real(baseline_filename)
+
+        secrets = live_secrets + audited_real_secrets
+
+        assert audited_real_return_code == live_return_code == ReportExitCode.FAIL.value
+        assert len(secrets) == len(expected_secrets)
+        assert [i for i in secrets if i not in expected_secrets] == []
+
+    def test_fail_live_and_unaudited_conditions_with_same_secret(self):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+        modified_baseline['results']['filenameA'][0]['is_verified'] = True
+        modified_baseline['results']['filenameA'][1]['is_secret'] = False
+        modified_baseline['results']['filenameB'][0]['is_secret'] = False
+
+        expected_secrets = [
+            {
+                'failed_condition': ReportSecretType.LIVE.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+            {
+                'failed_condition': ReportSecretType.UNAUDITED.value,
+                'filename': 'filenameA',
+                'line': modified_baseline['results']['filenameA'][0]['line_number'],
+                'type': 'Test Type',
+            },
+        ]
+
+        with self.mock_env(baseline=modified_baseline):
+            (live_return_code, live_secrets) = fail_on_live(baseline_filename)
+            (unaudited_return_code, unaudited_secrets) = fail_on_unaudited(baseline_filename)
+
+        secrets = live_secrets + unaudited_secrets
+
+        assert unaudited_return_code == live_return_code == ReportExitCode.FAIL.value
+        assert len(secrets) == len(expected_secrets)
+        assert [i for i in secrets if i not in expected_secrets] == []


### PR DESCRIPTION
## Related issue

Supports internal issue 623 in Team-backlog

## Description of changes

This is a sub-PR of https://github.com/IBM/detect-secrets/pull/46 (I'm breaking down the reporting PR for easier readability for reviewers).

- Added `get_secrets_list_from_file` to `audit.py`. This makes it simpler to extract a list of secrets from a baseline file. To be used by fail on functions to get secrets list, as well as for getting secrets information for the report console output.
- Added `conditions.py` to a reporting directory under `detect-secrets/core`. The functions within this file correspond to the report `fail-on-xx` CLI arguments.
- Added a `constants.py` file which contains exit report exit code and secret type enums ~as well as custom types~.
- Added a `conditions_test.py` file which contains various tests for the `fail-on` functionality.
- Added a `baseline.py` to the `testing` directory since I noticed this baseline dictionary object is reused throughout our testing files.