### PR TITLE
Rename --fail-on-non-audited to --fail-on-unaudited for pre-commit hook

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -69,7 +69,7 @@ class ParserBuilder(object):
             ._add_use_all_plugins_argument()\
             ._add_no_verify_flag() \
             ._add_output_verified_false_flag()\
-            ._add_fail_on_non_audited_flag()
+            ._add_fail_on_unaudited_flag()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -146,9 +146,9 @@ class ParserBuilder(object):
         add_output_verified_false_flag(self.parser)
         return self
 
-    def _add_fail_on_non_audited_flag(self):
+    def _add_fail_on_unaudited_flag(self):
         self.parser.add_argument(
-            '--fail-on-non-audited',
+            '--fail-on-unaudited',
             action='store_true',
             help='Fail check if there are entries have not been audited in baseline.',
         )

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -114,7 +114,7 @@ def main(argv=None):
         return 2
 
     # check if there are non-audited secrets
-    if args.fail_on_non_audited:
+    if args.fail_on_unaudited:
         non_audited = get_non_audited_secrets_from_baseline(
             baseline_collection,
         )
@@ -243,7 +243,7 @@ def pretty_print_diagnostics_for_non_audited(secrets):
 
     suggestions = [
         'Audit baseline file to make sure you have reviewed the risk',
-        'Remove the --fail-on-non-audited option from pre-commit hook',
+        'Remove the --fail-on-unaudited option from pre-commit hook',
     ]
 
     _print_warning_header(message)

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -186,7 +186,7 @@ Fail pre-commit if there are non-auditied entries in baseline file, even if the 
                 --baseline,
                 .secrets.baseline,
                 --use-all-plugins,
-                --fail-on-non-audited,
+                --fail-on-unaudited,
             ]
 ```
 

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -100,13 +100,13 @@ class TestPreCommitHook:
             (
                 True, False, None, None, '--baseline will_be_mocked '
                 + '--use-all-plugins test_data/files/file_with_no_secrets.py '
-                + '--fail-on-non-audited', 4,
+                + '--fail-on-unaudited', 4,
             ),
             # pass when clean file no non audited secret with fail-on-non-audited option
             (
                 True, False, True, None, '--baseline will_be_mocked '
                 + '--use-all-plugins test_data/files/file_with_no_secrets.py '
-                + '--fail-on-non-audited', 0,
+                + '--fail-on-unaudited', 0,
             ),
             # pass when clean file non audited secret without fail-on-non-audited option
             (

--- a/user-config/.pre-commit-config.yaml
+++ b/user-config/.pre-commit-config.yaml
@@ -16,5 +16,5 @@
         # You may also run `pre-commit run detect-secrets` to preview the scan result.
         # when "--baseline" without "--use-all-plugins", pre-commit scan with just plugins in baseline file
         # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
-        # add "--fail-on-non-audited" to fail pre-commit for unaudited potential secrets
+        # add "--fail-on-unaudited" to fail pre-commit for unaudited potential secrets
         args: [--baseline, .secrets.baseline, --use-all-plugins]


### PR DESCRIPTION
## Related issue

Supports internal issue 623 in Team-backlog

## Description of changes

This is a sub-PR of https://github.com/IBM/detect-secrets/pull/46 (I'm breaking down the reporting PR for easier readability for reviewers).

This PR refactors the `--fail-on-non-audited` pre-commit hook argument to `--fail-on-unaudited`. In the new reporting feature, one of the fail-on arguments will be `--fail-on-unaudited`, so it wouldn't make sense to have a pre-existing argument which conflicts with this name. Also, since the word `unaudited` is the correct dictionary spelling, I am opting to go with this naming convention. 

As a result of this change, users who are using `--fail-on-non-audited` in the pre-commit config files will need to use the updated argument name instead. I will include this breaking change in the announcement that will be posted in the internal Detect Secrets Slack channel.