### PR TITLE
Add reporting entrypoint file and its tests, and link it to main

### DIFF
--- a/detect_secrets/core/report/report.py
+++ b/detect_secrets/core/report/report.py
@@ -1,0 +1,148 @@
+import sys
+from argparse import ArgumentParser
+
+from detect_secrets.core.report.conditions import fail_on_audited_real
+from detect_secrets.core.report.conditions import fail_on_live
+from detect_secrets.core.report.conditions import fail_on_unaudited
+from detect_secrets.core.report.constants import ReportExitCode
+from detect_secrets.core.report.output import print_json_report
+from detect_secrets.core.report.output import print_stats
+from detect_secrets.core.report.output import print_summary
+from detect_secrets.core.report.output import print_table_report
+
+
+def execute(args) -> None:
+    """
+    Executes a report based off the given arguments.
+
+    This feature extends the audit subcommand; it is recommended to be run as a
+    CI / CD build stage for users who would like to have a Detect Secrets report
+    in their pipeline.
+
+    It will cause Detect Secrets to exit with an error code if secrets
+    within a baseline fail a user-provided set of conditions:
+
+    1. if they are active (--fail-on-live)
+    2. if have not been audited  (--fail-on-unaudited)
+    3. if they have been marked as real secrets when audited (--fail-on-audited-real)
+
+    A detailed report will be output that lists information about the secrets which failed
+    said conditions, including line number, filename, condition failed.There will be no
+    raw secret values in this output
+
+    Alternatively, assuming all conditions pass, Detect secrets will complete with zero exit status,
+    outputting a short summary stating that the checks passed, allowing the CI / CD build to
+    continue onto the next stage.
+
+    If no fail-on options are provided, all of the conditions will be
+    checked by default, but the report will always exit with zero.
+    """
+    unaudited_secrets = live_secrets = audited_real_secrets = []
+    unaudited_return_code = live_return_code = audited_real_return_code = ReportExitCode.PASS.value
+    default_conditions = False
+
+    # If no fail conditions provided, run report using all fail conditions, but exit with 0
+    if (
+        args.report
+        and not args.fail_on_unaudited
+        and not args.fail_on_audited_real
+        and not args.fail_on_live
+    ):
+        default_conditions = True
+
+    if args.fail_on_unaudited or default_conditions:
+        (unaudited_return_code, unaudited_secrets) = fail_on_unaudited(
+            args.filename[0],
+        )
+
+    if args.fail_on_live or default_conditions:
+        (live_return_code, live_secrets) = fail_on_live(args.filename[0])
+
+    if args.fail_on_audited_real or default_conditions:
+        (audited_real_return_code, audited_real_secrets) = fail_on_audited_real(
+            args.filename[0],
+        )
+
+    if args.json:
+        print_json_report(
+            live_secrets,
+            unaudited_secrets,
+            audited_real_secrets,
+            args.filename[0],
+            True if default_conditions else args.fail_on_live,
+            True if default_conditions else args.fail_on_unaudited,
+            True if default_conditions else args.fail_on_audited_real,
+        ),
+    else:
+        print_stats(
+            live_secrets,
+            unaudited_secrets,
+            audited_real_secrets,
+            args.filename[0],
+            True if default_conditions else args.fail_on_live,
+            True if default_conditions else args.fail_on_unaudited,
+            True if default_conditions else args.fail_on_audited_real,
+        )
+        print_table_report(
+            live_secrets,
+            unaudited_secrets,
+            audited_real_secrets,
+        )
+        print_summary(
+            unaudited_return_code,
+            live_return_code,
+            audited_real_return_code,
+            args.filename[0],
+            True if default_conditions else args.fail_on_live,
+            True if default_conditions else args.fail_on_unaudited,
+            True if default_conditions else args.fail_on_audited_real,
+            True if args.omit_instructions else False,
+        )
+
+    if (
+        unaudited_return_code
+        == live_return_code
+        == audited_real_return_code
+        == ReportExitCode.PASS.value
+    ):
+        sys.exit(ReportExitCode.PASS.value)
+    elif default_conditions:
+        sys.exit(ReportExitCode.PASS.value)
+    else:
+        sys.exit(ReportExitCode.FAIL.value)
+
+
+def validate_args(args, auditParser: ArgumentParser) -> None:
+    """
+    argsparse does not have a built-in option for mutually inclusive arguments,
+    so we have to do the additional report argument validation ourselves.
+    Specifically, there is no way to use argsparse to allow the report-specific.
+    arguments to only be used when --report is included.
+    """
+    if args.report:
+        return
+
+    if args.fail_on_unaudited:
+        auditParser.error(
+            'argument --fail-on-unaudited: not allowed without argument --report',
+        )
+
+    if args.fail_on_live:
+        auditParser.error(
+            'argument --fail-on-live: not allowed without argument --report',
+        )
+
+    if args.fail_on_audited_real:
+        auditParser.error(
+            'argument --fail-on-audited-real: not allowed without argument --report',
+        )
+
+    if args.omit_instructions:
+        auditParser.error(
+            'argument --omit-instructions: not allowed without argument --report',
+        )
+
+    if args.json:
+        auditParser.error(
+            'argument --json: not allowed without argument --report',
+        )

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -255,8 +255,8 @@ class AuditOptions:
         self.parser: argparse.ArgumentParser = subparser.add_parser(
             'audit',
             usage='%(prog)s [-h] [--diff |  --display-results | --report [--fail-on-unaudited]'
-            """ [--fail-on-live] [--fail-on-audited-real] [--json | --omit-instructions]]
-                     filename [filename ...]""",
+            ' [--fail-on-live] [--fail-on-audited-real] [--json | --omit-instructions]]'
+            ' [filename ...]',
         )
 
     def _add_report_module(self):
@@ -317,15 +317,6 @@ class AuditOptions:
         )
 
     def add_arguments(self):
-        self.parser.add_argument(
-            'filename',
-            nargs='+',
-            help=(
-                'Audit a given baseline file to distinguish the difference '
-                'between false and true positives.'
-            ),
-        )
-
         action_parser = self.parser.add_mutually_exclusive_group()
 
         action_parser.add_argument(
@@ -354,6 +345,15 @@ class AuditOptions:
         )
 
         self._add_report_module()
+
+        self.parser.add_argument(
+            'filename',
+            nargs='+',
+            help=(
+                'Audit a given baseline file to distinguish the difference '
+                'between false and true positives.'
+            ),
+        )
 
         return self
 

--- a/tests/core/report/report_test.py
+++ b/tests/core/report/report_test.py
@@ -1,0 +1,300 @@
+from contextlib import contextmanager
+from copy import deepcopy
+
+import mock
+import pytest
+
+from detect_secrets.core import audit as audit_module
+from detect_secrets.core.report.constants import ReportExitCode
+from detect_secrets.main import main
+from testing.baseline import baseline
+
+
+@pytest.fixture
+def mock_print_table_report():
+    with mock.patch(
+        'detect_secrets.core.report.report.print_table_report',
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_print_stats():
+    with mock.patch(
+        'detect_secrets.core.report.report.print_stats',
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_print_summary():
+    with mock.patch(
+        'detect_secrets.core.report.report.print_summary',
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_print_json_report():
+    with mock.patch(
+        'detect_secrets.core.report.report.print_json_report',
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_fail_on_unaudited():
+    with mock.patch(
+        'detect_secrets.core.report.report.fail_on_unaudited',
+        return_value=(ReportExitCode.PASS.value, []),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_fail_on_live():
+    with mock.patch(
+        'detect_secrets.core.report.report.fail_on_live',
+        return_value=(ReportExitCode.PASS.value, []),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_fail_on_audited_real():
+    with mock.patch(
+        'detect_secrets.core.report.report.fail_on_audited_real',
+        return_value=(ReportExitCode.PASS.value, []),
+    ) as m:
+        yield m
+
+
+class TestReport:
+    """
+    These are smoke tests for the console usage of the detect_secrets
+    report feature.
+    """
+
+    @contextmanager
+    def mock_env(self, baseline=None):
+        if baseline is None:
+            baseline = self.baseline
+
+        with mock.patch.object(
+            # We mock this, so we don't need to do any file I/O.
+            audit_module,
+            '_get_baseline_from_file',
+            return_value=baseline,
+        ) as m:
+            yield m
+
+    @property
+    def baseline(self):
+        return baseline
+
+    def test_fail_on_unaudited_mutually_inclusive_with_report(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --fail-on-unaudited fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'argument --fail-on-unaudited: not allowed without argument --report' in captured.err
+
+    def test_fail_on_live_mutually_inclusive_with_report(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --fail-on-live fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'argument --fail-on-live: not allowed without argument --report' in captured.err
+
+    def test_fail_on_audited_real_mutually_inclusive_with_report(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --fail-on-audited-real fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert (
+            'argument --fail-on-audited-real: not allowed without argument --report' in captured.err
+        )
+
+    def test_omit_instructions_mutually_inclusive_with_report(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --omit-instructions fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'argument --omit-instructions: not allowed without argument --report' in captured.err
+
+    def test_json_mutually_inclusive_with_report(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --json fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'argument --json: not allowed without argument --report' in captured.err
+
+    def test_json_mutually_exclusive_with_omit_instructions(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --report --json --omit-instructions fileA'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'argument --omit-instructions: not allowed with argument --json' in captured.err
+
+    def test_report_without_file(self, capsys):
+        with pytest.raises(SystemExit):
+            main('audit --report'.split())
+
+        captured = capsys.readouterr()
+
+        assert 'the following arguments are required: filename' in captured.err
+
+    def test_default_report_prints_table_output(
+        self,
+        mock_print_stats,
+        mock_print_table_report,
+        mock_print_summary,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report fileA'.split())
+
+        mock_print_stats.assert_called()
+        mock_print_table_report.assert_called()
+        mock_print_summary.assert_called()
+
+    def test_default_report_runs_all_checks(
+        self,
+        mock_fail_on_unaudited,
+        mock_fail_on_live,
+        mock_fail_on_audited_real,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report fileA'.split())
+
+        mock_fail_on_unaudited.assert_called()
+        mock_fail_on_live.assert_called()
+        mock_fail_on_audited_real.assert_called()
+
+    def test_default_report_always_exits_with_code_zero(self):
+        with self.mock_env(), pytest.raises(SystemExit) as context:
+            main('audit --report fileA'.split())
+
+        assert context.type == SystemExit
+        assert context.value.code == ReportExitCode.PASS.value
+
+    def test_json_report(self, mock_print_json_report):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --json fileA'.split())
+
+        mock_print_json_report.assert_called()
+
+    def test_json_report_prints_json_output(
+        self,
+        mock_print_json_report,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --json fileA'.split())
+
+        mock_print_json_report.assert_called()
+
+    def test_default_json_report_executes_all_conditions(
+        self,
+        mock_fail_on_unaudited,
+        mock_fail_on_live,
+        mock_fail_on_audited_real,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --json fileA'.split())
+
+        mock_fail_on_unaudited.assert_called()
+        mock_fail_on_live.assert_called()
+        mock_fail_on_audited_real.assert_called()
+
+    def test_default_json_report_always_exits_with_code_zero(self):
+        with self.mock_env(), pytest.raises(SystemExit) as context:
+            main('audit --report --json fileA'.split())
+
+        assert context.type == SystemExit
+        assert context.value.code == ReportExitCode.PASS.value
+
+    def test_json_report_with_all_fail_conditions_exits_with_non_zero_upon_failure(self):
+        with self.mock_env(), pytest.raises(SystemExit) as context:
+            main(
+                'audit --report --json --fail-on-unaudited'
+                ' --fail-on-live --fail-on-audited-real fileA'.split(),
+            )
+
+        assert context.type == SystemExit
+        assert context.value.code == ReportExitCode.FAIL.value
+
+    def test_report_with_all_fail_on_conditions_executes_all_conditions(
+        self,
+        mock_fail_on_unaudited,
+        mock_fail_on_live,
+        mock_fail_on_audited_real,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main(
+                'audit --report --fail-on-unaudited --fail-on-live'
+                ' --fail-on-audited-real fileA'.split(),
+            )
+
+        mock_fail_on_unaudited.assert_called()
+        mock_fail_on_live.assert_called()
+        mock_fail_on_audited_real.assert_called()
+
+    def test_report_with_all_fail_on_conditions_exits_with_non_zero_upon_failure(self):
+        modified_baseline = deepcopy(self.baseline)
+        print(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+        modified_baseline['results']['filenameA'][1]['is_secret'] = None
+        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+
+        with self.mock_env(baseline=modified_baseline), pytest.raises(SystemExit) as context:
+            main(
+                'audit --report --fail-on-unaudited --fail-on-live'
+                ' --fail-on-audited-real fileA'.split(),
+            )
+
+        assert context.type == SystemExit
+        assert context.value.code == ReportExitCode.FAIL.value
+
+    def test_report_fail_on_live_only(
+        self,
+        mock_fail_on_live,
+        mock_fail_on_unaudited,
+        mock_fail_on_audited_real,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --fail-on-live fileA'.split())
+
+        mock_fail_on_live.assert_called()
+        mock_fail_on_unaudited.assert_not_called()
+        mock_fail_on_audited_real.assert_not_called()
+
+    def test_report_fail_on_audited_real_only(
+        self,
+        mock_fail_on_audited_real,
+        mock_fail_on_unaudited,
+        mock_fail_on_live,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --fail-on-audited-real fileA'.split())
+
+        mock_fail_on_audited_real.assert_called()
+        mock_fail_on_unaudited.assert_not_called()
+        mock_fail_on_live.assert_not_called()
+
+    def test_report_fail_on_unaudited_only(
+        self,
+        mock_fail_on_unaudited,
+        mock_fail_on_audited_real,
+        mock_fail_on_live,
+    ):
+        with self.mock_env(), pytest.raises(SystemExit):
+            main('audit --report --fail-on-unaudited fileA'.split())
+
+        mock_fail_on_unaudited.assert_called()
+        mock_fail_on_audited_real.assert_not_called()
+        mock_fail_on_live.assert_not_called()

--- a/tests/core/report/report_test.py
+++ b/tests/core/report/report_test.py
@@ -77,14 +77,11 @@ class TestReport:
 
     @contextmanager
     def mock_env(self, baseline=None):
-        if baseline is None:
-            baseline = self.baseline
-
         with mock.patch.object(
             # We mock this, so we don't need to do any file I/O.
             audit_module,
             '_get_baseline_from_file',
-            return_value=baseline,
+            return_value=baseline or self.baseline,
         ) as m:
             yield m
 


### PR DESCRIPTION
## Related issue

Supports internal issue 623 in Team-backlog

## Description of changes

This is a sub-PR of https://github.com/IBM/detect-secrets/pull/46 (I'm breaking down the reporting PR for easier readability for reviewers).

- Adds `report.py`, which serves as the entrypoint for the audit reporting functionality.
- Adds report.py execute function to `main.py`, so reporting can now be used.
- Adds tests for reporting
- `usage.py`: moves filename argument to end, updates usage string to be more readable.