### PR TITLE
Don't include unnecessary newlines when omitting report output instructions

### DIFF
--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -206,12 +206,12 @@ def print_summary(
             )
         return
 
-    print('\nFailed conditions:')
+    print('\nFailed conditions:\n')
 
     if fail_on_unaudited and unaudited_return_code != 0:
         print(
             '{}\n'.format(
-                colorize('\n\t- Unaudited secrets were found', AnsiColor.BOLD),
+                colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
             ),
         )
         if omit_instructions is False:
@@ -223,7 +223,7 @@ def print_summary(
     if fail_on_live and live_return_code != 0:
         print(
             '{}\n'.format(
-                colorize('\n\t- Live secrets were found', AnsiColor.BOLD),
+                colorize('\t- Live secrets were found', AnsiColor.BOLD),
             ),
         )
         if omit_instructions is False:
@@ -237,7 +237,7 @@ def print_summary(
     if fail_on_audited_real and audited_real_return_code != 0:
         print(
             '{}\n'.format(
-                colorize('\n\t- Audited true secrets were found', AnsiColor.BOLD),
+                colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             ),
         )
         if omit_instructions is False:

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -698,17 +698,17 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n'.format(
-            colorize('\n\t- Unaudited secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n'.format(
+            colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
             '\n\t\tRun detect-secrets audit {}, and audit all potential secrets.'.format(
                 baseline_filename,
             ),
-            colorize('\n\t- Live secrets were found', AnsiColor.BOLD),
+            colorize('\t- Live secrets were found', AnsiColor.BOLD),
             '\n\t\tRevoke all live secrets and remove them from the codebase.'
             ' Afterwards, run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
             ),
-            colorize('\n\t- Audited true secrets were found', AnsiColor.BOLD),
+            colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tRemove secrets meeting this condition from the codebase,'
             ' and run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
@@ -732,10 +732,10 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n\n{}\n\n{}\n\n'.format(
-            colorize('\n\t- Unaudited secrets were found', AnsiColor.BOLD),
-            colorize('\n\t- Live secrets were found', AnsiColor.BOLD),
-            colorize('\n\t- Audited true secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n\n{}\n\n{}\n\n'.format(
+            colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
+            colorize('\t- Live secrets were found', AnsiColor.BOLD),
+            colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
         )
 
     def test_print_summary_only_live_pass(self, capsys):
@@ -814,8 +814,8 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n{}\n{}\n'.format(
-            colorize('\n\t- Live secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n'.format(
+            colorize('\t- Live secrets were found', AnsiColor.BOLD),
             '\n\t\tRevoke all live secrets and remove them from the codebase.'
             ' Afterwards, run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
@@ -839,8 +839,8 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n\n'.format(
-            colorize('\n\t- Live secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n\n'.format(
+            colorize('\t- Live secrets were found', AnsiColor.BOLD),
         )
 
     def test_print_summary_only_unaudited_fail(self, capsys):
@@ -859,8 +859,8 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n{}\n{}\n'.format(
-            colorize('\n\t- Unaudited secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n'.format(
+            colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
             '\n\t\tRun detect-secrets audit {}, and audit all potential secrets.'.format(
                 baseline_filename,
             ),
@@ -883,8 +883,8 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n\n'.format(
-            colorize('\n\t- Unaudited secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n\n'.format(
+            colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
         )
 
     def test_print_summary_only_audited_real_fail(self, capsys):
@@ -903,8 +903,8 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n{}\n{}\n'.format(
-            colorize('\n\t- Audited true secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n'.format(
+            colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tRemove secrets meeting this condition from the codebase,'
             ' and run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
@@ -928,6 +928,6 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n{}\n\n'.format(
-            colorize('\n\t- Audited true secrets were found', AnsiColor.BOLD),
+        assert captured.out == '\nFailed conditions:\n\n{}\n\n'.format(
+            colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
         )


### PR DESCRIPTION
## Description
Fixes `detect-secrets audit --report --omit-instructions .secrets.baseline` output. In the case where the `--omit-instructions` argument is included and there are secret results which fail conditions, additional newlines are included in the output, making it inconsistent with the rest of the reporting output cases.

So this:
```
$ detect-secrets audit --report --omit-instructions .secrets.baseline

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              68
Unaudited           Private Key              detect_secrets/plugins/private_key.py      49
Audited as real     Private Key              detect_secrets/plugins/private_key.py      51

Failed conditions:

        - Unaudited secrets were found


        - Live secrets were found


        - Audited true secrets were found

```

will now use the correct spacing:
```
$ detect-secrets audit --report --omit-instructions .secrets.baseline

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              68
Unaudited           Private Key              detect_secrets/plugins/private_key.py      49
Audited as real     Private Key              detect_secrets/plugins/private_key.py      51

Failed conditions:

        - Unaudited secrets were found

        - Live secrets were found

        - Audited true secrets were found

```