### PR TITLE
Fix inconsistencies with fail-on stats text output

### DIFF
--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -146,20 +146,21 @@ def print_stats(
         stats += ' {} live secret{}{}'.format(
             colorize(len(live_secrets), AnsiColor.BOLD),
             's' if len(live_secrets) > 1 or len(live_secrets) == 0 else '',
-            '.' if not fail_on_unaudited and not fail_on_audited_real else '',
+            '.\n' if not fail_on_unaudited and not fail_on_audited_real else '',
         )
 
     if fail_on_unaudited:
-        stats += '{} {} unaudited secret{}{}'.format(
-            ',' if fail_on_audited_real else '',
+        stats += '{}{} {} unaudited secret{}{}'.format(
+            ',' if fail_on_audited_real and fail_on_live else '',
+            ' and' if not fail_on_audited_real and fail_on_live else '',
             colorize(len(unaudited_secrets), AnsiColor.BOLD),
             's' if len(unaudited_secrets) > 1 or len(unaudited_secrets) == 0 else '',
-            '.' if not fail_on_audited_real else '',
+            '.\n' if not fail_on_audited_real else '',
         )
 
     if fail_on_audited_real:
-        stats += ' {} {} secret{} that {} audited as real.\n'.format(
-            'and' if fail_on_live or fail_on_audited_real else '',
+        stats += ' {}{} secret{} that {} audited as real.\n'.format(
+            'and ' if fail_on_live or fail_on_unaudited else '',
             colorize(len(audited_real_secrets), AnsiColor.BOLD),
             's' if len(audited_real_secrets) > 1 or len(audited_real_secrets) == 0 else '',
             'were' if len(audited_real_secrets) > 1 or len(audited_real_secrets) == 0 else 'was',

--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -143,16 +143,18 @@ def print_stats(
     )
 
     if fail_on_live:
-        stats += ' {} live secret{}'.format(
+        stats += ' {} live secret{}{}'.format(
             colorize(len(live_secrets), AnsiColor.BOLD),
             's' if len(live_secrets) > 1 or len(live_secrets) == 0 else '',
+            '.' if not fail_on_unaudited and not fail_on_audited_real else '',
         )
 
     if fail_on_unaudited:
-        stats += '{} {} unaudited secret{},'.format(
-            ',' if fail_on_live else '',
+        stats += '{} {} unaudited secret{}{}'.format(
+            ',' if fail_on_audited_real else '',
             colorize(len(unaudited_secrets), AnsiColor.BOLD),
             's' if len(unaudited_secrets) > 1 or len(unaudited_secrets) == 0 else '',
+            '.' if not fail_on_audited_real else '',
         )
 
     if fail_on_audited_real:

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -243,7 +243,7 @@ Fail (still exit code = 0 because of no provided `--fail-on` arguments!):
 ```
 $ detect-secrets audit --report .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.
 
 Failed Condition    Secret Type              Filename                                 Line
 ------------------  -----------------------  -------------------------------------  ------
@@ -276,7 +276,7 @@ Fail (still exit code = 0 because of no provided `--fail-on` arguments!):
 ```
 $ detect-secrets audit --report --omit-instructions .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.
 
 Failed Condition    Secret Type              Filename                                 Line
 ------------------  -----------------------  -------------------------------------  ------
@@ -316,7 +316,7 @@ Fail (exit code = 1):
 ```
 $ detect-secrets audit --report --fail-on-live --fail-on-unaudited --fail-on-audited-real .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.
 
 Failed Condition    Secret Type              Filename                                 Line
 ------------------  -----------------------  -------------------------------------  ------
@@ -349,7 +349,7 @@ Fail (exit code = 1):
 ```
 $ detect-secrets audit --report --fail-on-live --fail-on-unaudited --fail-on-audited-real --omit-instructions  .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.
 
 Failed Condition    Secret Type              Filename                                 Line
 ------------------  -----------------------  -------------------------------------  ------
@@ -385,7 +385,7 @@ Fail (exit code = 1):
 ```
 $ detect-secrets audit --report --fail-on-live .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret.
 Failed Condition    Secret Type              Filename        Line
 ------------------  -----------------------  ------------  ------
 Live                Hex High Entropy String  docs/scan.md      49
@@ -407,7 +407,7 @@ Fail (exit code = 1):
 ```
 $ detect-secrets audit --report --fail-on-live --omit-instructions .secrets.baseline
 
-10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret
+10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret.
 Failed Condition    Secret Type              Filename        Line
 ------------------  -----------------------  ------------  ------
 Live                Hex High Entropy String  docs/scan.md      49

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -255,7 +255,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secret, {} unaudited secret,'.format(
+        ) + ' Found {} live secret, {} unaudited secret'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         ) + ' and {} secret that was audited as real.\n\n'.format(
@@ -340,7 +340,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secrets, {} unaudited secrets,'.format(
+        ) + ' Found {} live secrets, {} unaudited secrets'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         ) + ' and {} secrets that were audited as real.\n\n'.format(
@@ -378,11 +378,188 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secret, {} unaudited secrets,'.format(
+        ) + ' Found {} live secret, {} unaudited secrets'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         ) + ' and {} secrets that were audited as real.\n\n'.format(
             colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
+        )
+
+    def print_stats_only_unaudited(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                False,
+                True,
+                False,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} unaudited secrets.'.format(
+            colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
+        )
+
+    def print_stats_only_unaudited_and_live(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                True,
+                True,
+                False,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} live secret and {} unaudited secret'.format(
+            colorize(len(live_secrets_fixture), AnsiColor.BOLD),
+            colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
+        )
+
+    def print_stats_only_unaudited_and_audited_real(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+        modified_baseline['results']['filenameB'][0]['is_secret'] = True
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                False,
+                True,
+                True,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} unaudited secret and {} secret that was audited as real'.format(
+            colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
+            colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
+        )
+
+    def print_stats_only_live(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_verified'] = True
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                True,
+                False,
+                False,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} live secrets.'.format(
+            colorize(len(live_secrets_fixture), AnsiColor.BOLD),
+        )
+
+    # def print_stats_only_live_and_audited_real(
+    #     self,
+    #     capsys,
+    #     live_secrets_fixture,
+    #     unaudited_secrets_fixture,
+    #     audited_real_secrets_fixture,
+    # ):
+
+    def print_stats_only_audited_real(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                False,
+                False,
+                True,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} secrets that were audited as real.'.format(
+            colorize(len(live_secrets_fixture), AnsiColor.BOLD),
         )
 
     def test_print_report_table_no_failed_conditions(

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -103,7 +103,6 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-
         with self.mock_env():
             stats = get_stats(
                 live_secrets_fixture,
@@ -129,7 +128,6 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-
         with self.mock_env():
             stats = get_stats(
                 live_secrets_fixture,
@@ -153,7 +151,6 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-
         with self.mock_env():
             stats = get_stats(
                 live_secrets_fixture,
@@ -177,7 +174,6 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-
         with self.mock_env():
             stats = get_stats(
                 live_secrets_fixture,
@@ -233,12 +229,7 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = True
-        modified_baseline['results']['filenameA'][1]['is_secret'] = None
-        modified_baseline['results']['filenameB'][0]['is_verified'] = True
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -354,14 +345,9 @@ class TestReportOutput:
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = False
-        modified_baseline['results']['filenameA'][1]['is_secret'] = False
-        modified_baseline['results']['filenameB'][0]['is_verified'] = True
-
         unaudited_secrets_fixture = audited_real_secrets_fixture = []
 
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -385,19 +371,16 @@ class TestReportOutput:
             colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_unaudited(
+    def test_print_stats_only_unaudited(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = None
+        live_secrets_fixture = audited_real_secrets_fixture = []
 
-        unaudited_secrets_fixture = audited_real_secrets_fixture = []
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -414,24 +397,20 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} unaudited secrets.\n\n'.format(
+        ) + ' Found {} unaudited secret.\n\n'.format(
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_unaudited_and_live(
+    def test_print_stats_only_unaudited_and_live(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = None
-        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+        audited_real_secrets_fixture = []
 
-        unaudited_secrets_fixture = audited_real_secrets_fixture = []
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -453,20 +432,16 @@ class TestReportOutput:
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_unaudited_and_audited_real(
+    def test_print_stats_only_unaudited_and_audited_real(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = None
-        modified_baseline['results']['filenameB'][0]['is_secret'] = True
+        live_secrets_fixture = []
 
-        unaudited_secrets_fixture = audited_real_secrets_fixture = []
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -488,19 +463,16 @@ class TestReportOutput:
             colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_live(
+    def test_print_stats_only_live(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_verified'] = True
-
         unaudited_secrets_fixture = audited_real_secrets_fixture = []
 
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -517,31 +489,27 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secrets.\n\n'.format(
+        ) + ' Found {} live secret.\n\n'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_live_and_audited_real(
+    def test_print_stats_only_live_and_audited_real(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = True
-        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+        unaudited_secrets_fixture = []
 
-        unaudited_secrets_fixture = audited_real_secrets_fixture = []
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
                 audited_real_secrets_fixture,
                 baseline_filename,
-                False,
                 True,
+                False,
                 True,
             )
             secrets = audit.get_secrets_list_from_file(baseline_filename)
@@ -552,23 +520,20 @@ class TestReportOutput:
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
         ) + ' Found {} live secret and {} secret that was audited as real.\n\n'.format(
-            colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
+            colorize(len(live_secrets_fixture), AnsiColor.BOLD),
             colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
         )
 
-    def print_stats_only_audited_real(
+    def test_print_stats_only_audited_real(
         self,
         capsys,
         live_secrets_fixture,
         unaudited_secrets_fixture,
         audited_real_secrets_fixture,
     ):
-        modified_baseline = deepcopy(self.baseline)
-        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+        unaudited_secrets_fixture = live_secrets_fixture = []
 
-        unaudited_secrets_fixture = audited_real_secrets_fixture = []
-
-        with self.mock_env(baseline=modified_baseline):
+        with self.mock_env():
             print_stats(
                 live_secrets_fixture,
                 unaudited_secrets_fixture,
@@ -585,8 +550,8 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} secrets that were audited as real.\n\n'.format(
-            colorize(len(live_secrets_fixture), AnsiColor.BOLD),
+        ) + ' Found {} secret that was audited as real.\n\n'.format(
+            colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
         )
 
     def test_print_report_table_no_failed_conditions(

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -414,7 +414,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} unaudited secrets.'.format(
+        ) + ' Found {} unaudited secrets.\n\n'.format(
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         )
 
@@ -448,7 +448,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secret and {} unaudited secret'.format(
+        ) + ' Found {} live secret and {} unaudited secret.\n\n'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
         )
@@ -483,7 +483,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} unaudited secret and {} secret that was audited as real'.format(
+        ) + ' Found {} unaudited secret and {} secret that was audited as real.\n\n'.format(
             colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
             colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
         )
@@ -517,17 +517,44 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} live secrets.'.format(
+        ) + ' Found {} live secrets.\n\n'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
         )
 
-    # def print_stats_only_live_and_audited_real(
-    #     self,
-    #     capsys,
-    #     live_secrets_fixture,
-    #     unaudited_secrets_fixture,
-    #     audited_real_secrets_fixture,
-    # ):
+    def print_stats_only_live_and_audited_real(
+        self,
+        capsys,
+        live_secrets_fixture,
+        unaudited_secrets_fixture,
+        audited_real_secrets_fixture,
+    ):
+        modified_baseline = deepcopy(self.baseline)
+        modified_baseline['results']['filenameA'][0]['is_secret'] = True
+        modified_baseline['results']['filenameB'][0]['is_verified'] = True
+
+        unaudited_secrets_fixture = audited_real_secrets_fixture = []
+
+        with self.mock_env(baseline=modified_baseline):
+            print_stats(
+                live_secrets_fixture,
+                unaudited_secrets_fixture,
+                audited_real_secrets_fixture,
+                baseline_filename,
+                False,
+                True,
+                True,
+            )
+            secrets = audit.get_secrets_list_from_file(baseline_filename)
+
+        captured = capsys.readouterr()
+
+        assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
+            colorize(len(secrets), AnsiColor.BOLD),
+            colorize(baseline_filename, AnsiColor.BOLD),
+        ) + ' Found {} live secret and {} secret that was audited as real.\n\n'.format(
+            colorize(len(unaudited_secrets_fixture), AnsiColor.BOLD),
+            colorize(len(audited_real_secrets_fixture), AnsiColor.BOLD),
+        )
 
     def print_stats_only_audited_real(
         self,
@@ -558,7 +585,7 @@ class TestReportOutput:
         assert captured.out == '\n{} potential secrets in {} were reviewed.'.format(
             colorize(len(secrets), AnsiColor.BOLD),
             colorize(baseline_filename, AnsiColor.BOLD),
-        ) + ' Found {} secrets that were audited as real.'.format(
+        ) + ' Found {} secrets that were audited as real.\n\n'.format(
             colorize(len(live_secrets_fixture), AnsiColor.BOLD),
         )
 


### PR DESCRIPTION
Fixes the following output:

### detect-secrets audit --report --fail-on-audited-real .secrets.baseline

#### Before
```

10 potential secrets in .secrets.baseline were reviewed. Found and 1 secret that was audited as real.

Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Audited as real     Private Key    detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

#### After
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 secret that was audited as real.

Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Audited as real     Private Key    detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

### detect-secrets audit --report --fail-on-unaudited .secrets.baseline

#### Before

```

10 potential secrets in .secrets.baseline were reviewed. Found 1 unaudited secret,
Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Unaudited           Private Key    detect_secrets/plugins/private_key.py      46

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.

For additional help, run detect-secrets audit --help.

```

#### After
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 unaudited secret.

Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Unaudited           Private Key    detect_secrets/plugins/private_key.py      46

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.

For additional help, run detect-secrets audit --help.

```

### detect-secrets audit --report --fail-on-live .secrets.baseline

#### Before
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret
Failed Condition    Secret Type              Filename         Line
------------------  -----------------------  -------------  ------
Live                Hex High Entropy String  docs/audit.md      83

Failed conditions:

        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

#### After
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret.

Failed Condition    Secret Type              Filename         Line
------------------  -----------------------  -------------  ------
Live                Hex High Entropy String  docs/audit.md      83

Failed conditions:

        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

### detect-secrets audit --report --fail-on-live --fail-on-unaudited .secrets.baseline

#### Before
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret,
Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              83
Unaudited           Private Key              detect_secrets/plugins/private_key.py      46

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

#### After 

```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret and 1 unaudited secret.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              83
Unaudited           Private Key              detect_secrets/plugins/private_key.py      46

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

### detect-secrets audit --report --fail-on-unaudited --fail-on-audited-real .secrets.baseline

#### Before
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 unaudited secret, and 1 secret that was audited as real.

Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Unaudited           Private Key    detect_secrets/plugins/private_key.py      46
Audited as real     Private Key    detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

#### After

```

10 potential secrets in .secrets.baseline were reviewed. Found 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type    Filename                                 Line
------------------  -------------  -------------------------------------  ------
Unaudited           Private Key    detect_secrets/plugins/private_key.py      46
Audited as real     Private Key    detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

### detect-secrets audit --report --fail-on-unaudited --fail-on-audited-real --fail-on-live .secrets.baseline

#### Before

```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret, and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              83
Unaudited           Private Key              detect_secrets/plugins/private_key.py      46
Audited as real     Private Key              detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.
        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

#### After
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/audit.md                              83
Unaudited           Private Key              detect_secrets/plugins/private_key.py      46
Audited as real     Private Key              detect_secrets/plugins/private_key.py      45

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.
        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

^ I removed the usage of the oxford comma since it was causing issues.