### PR TITLE
add yum update to container

### DIFF
--- a/Dockerfiles/detect-secrets-redhat-ubi/00.python-redhat-ubi.Dockerfile
+++ b/Dockerfiles/detect-secrets-redhat-ubi/00.python-redhat-ubi.Dockerfile
@@ -1,2 +1,5 @@
 FROM registry.access.redhat.com/ubi8/python-39
 LABEL maintainer="squad:git-defenders" url="https://github.ibm.com/whitewater/whitewater-detect-secrets"
+
+User root
+RUN yum -y update


### PR DESCRIPTION
Starting with the Redhat ubi:python-39  UBI image, run the yum update to update the packages.  ie grab updates to get any fixed vulnerabilities fixes.