### PR TITLE
Fix reporting spacing

### DIFF
--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -219,7 +219,7 @@ def print_summary(
         )
         if omit_instructions is False:
             print(
-                '\t\tRun detect-secrets audit {}, and audit all potential secrets.'.format(
+                '\t\tRun detect-secrets audit {}, and audit all potential secrets.\n'.format(
                     baseline_filename,
                 ),
             )
@@ -232,7 +232,7 @@ def print_summary(
         if omit_instructions is False:
             print(
                 '\t\tRevoke all live secrets and remove them from the codebase.'
-                ' Afterwards, run detect-secrets scan --update {} to re-scan.'.format(
+                ' Afterwards, run detect-secrets scan --update {} to re-scan.\n'.format(
                     baseline_filename,
                 ),
             )
@@ -246,8 +246,8 @@ def print_summary(
         if omit_instructions is False:
             print(
                 '\t\tRemove secrets meeting this condition from the codebase,'
-                ' and run detect-secrets scan --update {} to re-scan.'.format(baseline_filename),
+                ' and run detect-secrets scan --update {} to re-scan.\n'.format(baseline_filename),
             )
 
     if omit_instructions is False:
-        print('\nFor additional help, run detect-secrets audit --help.\n')
+        print('For additional help, run detect-secrets audit --help.\n')

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -869,20 +869,20 @@ Audited as real     Test Type      filenameB       60\n"""
 
         assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n'.format(
             colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
-            '\n\t\tRun detect-secrets audit {}, and audit all potential secrets.'.format(
+            '\n\t\tRun detect-secrets audit {}, and audit all potential secrets.\n'.format(
                 baseline_filename,
             ),
             colorize('\t- Live secrets were found', AnsiColor.BOLD),
             '\n\t\tRevoke all live secrets and remove them from the codebase.'
-            ' Afterwards, run detect-secrets scan --update {} to re-scan.'.format(
+            ' Afterwards, run detect-secrets scan --update {} to re-scan.\n'.format(
                 baseline_filename,
             ),
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tRemove secrets meeting this condition from the codebase,'
-            ' and run detect-secrets scan --update {} to re-scan.'.format(
+            ' and run detect-secrets scan --update {} to re-scan.\n'.format(
                 baseline_filename,
             ),
-            '\nFor additional help, run detect-secrets audit --help.\n',
+            'For additional help, run detect-secrets audit --help.\n',
         )
 
     def test_print_summary_all_failed_conditions_omit_instructions(self, capsys):


### PR DESCRIPTION
Before:

```
$ detect-secrets audit --report .secrets.baseline

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/scan.md                               49
Unaudited           Private Key              detect_secrets/plugins/private_key.py      51
Audited as real     Private Key              detect_secrets/plugins/private_key.py      50

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.
        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.
        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.
```

After:
```

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/scan.md                               49
Unaudited           Private Key              detect_secrets/plugins/private_key.py      51
Audited as real     Private Key              detect_secrets/plugins/private_key.py      50

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.

        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```