### PR TITLE
Reword audited real help text to be more specific

### DIFF
--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -246,7 +246,7 @@ def print_summary(
         if omit_instructions is False:
             print(
                 '\t\tIf any active secrets meet this condition, revoke them.'
-                ' Then, remove them from the codebase'
+                ' Then, remove secrets that were audited as real from the codebase'
                 ' and run detect-secrets scan --update {} to re-scan.\n'.format(baseline_filename),
             )
 

--- a/detect_secrets/core/report/output.py
+++ b/detect_secrets/core/report/output.py
@@ -245,7 +245,8 @@ def print_summary(
         )
         if omit_instructions is False:
             print(
-                '\t\tRemove secrets meeting this condition from the codebase,'
+                '\t\tIf any active secrets meet this condition, revoke them.'
+                ' Then, remove them from the codebase'
                 ' and run detect-secrets scan --update {} to re-scan.\n'.format(baseline_filename),
             )
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -263,7 +263,7 @@ Failed conditions:
 
         - Audited true secrets were found
 
-                If any active secrets meet this condition, revoke them. Then, remove them from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
+                If any active secrets meet this condition, revoke them. Then, remove secrets that were audited as real from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
 
 For additional help, run detect-secrets audit --help.
 
@@ -336,7 +336,7 @@ Failed conditions:
 
         - Audited true secrets were found
 
-                If any active secrets meet this condition, revoke them. Then, remove them from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
+                If any active secrets meet this condition, revoke them. Then, remove secrets that were audited as real from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
 
 For additional help, run detect-secrets audit --help.
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -263,7 +263,7 @@ Failed conditions:
 
         - Audited true secrets were found
 
-                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.
+                If any active secrets meet this condition, revoke them. Then, remove them from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
 
 For additional help, run detect-secrets audit --help.
 
@@ -336,7 +336,7 @@ Failed conditions:
 
         - Audited true secrets were found
 
-                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.
+                If any active secrets meet this condition, revoke them. Then, remove them from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.
 
 For additional help, run detect-secrets audit --help.
 

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -879,7 +879,7 @@ Audited as real     Test Type      filenameB       60\n"""
             ),
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tIf any active secrets meet this condition, revoke them.',
-            ' Then, remove them from the codebase and',
+            ' Then, remove all secrets that were audited as real from the codebase and',
             ' run detect-secrets scan --update {} to re-scan.\n'.format(
                 baseline_filename,
             ),
@@ -1076,7 +1076,7 @@ Audited as real     Test Type      filenameB       60\n"""
         assert captured.out == '\nFailed conditions:\n\n{}\n{}{}{}\n{}\n'.format(
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tIf any active secrets meet this condition, revoke them.',
-            ' Then, remove them from the codebase and',
+            ' Then, remove secrets that were audited as real them from the codebase and',
             ' run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
             ),

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -879,7 +879,7 @@ Audited as real     Test Type      filenameB       60\n"""
             ),
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tIf any active secrets meet this condition, revoke them.',
-            ' Then, remove all secrets that were audited as real from the codebase and',
+            ' Then, remove secrets that were audited as real from the codebase and',
             ' run detect-secrets scan --update {} to re-scan.\n'.format(
                 baseline_filename,
             ),
@@ -1076,7 +1076,7 @@ Audited as real     Test Type      filenameB       60\n"""
         assert captured.out == '\nFailed conditions:\n\n{}\n{}{}{}\n{}\n'.format(
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
             '\n\t\tIf any active secrets meet this condition, revoke them.',
-            ' Then, remove secrets that were audited as real them from the codebase and',
+            ' Then, remove secrets that were audited as real from the codebase and',
             ' run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
             ),

--- a/tests/core/report/output_test.py
+++ b/tests/core/report/output_test.py
@@ -867,7 +867,7 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n'.format(
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n{}\n{}\n{}{}{}\n{}\n'.format(
             colorize('\t- Unaudited secrets were found', AnsiColor.BOLD),
             '\n\t\tRun detect-secrets audit {}, and audit all potential secrets.\n'.format(
                 baseline_filename,
@@ -878,8 +878,9 @@ Audited as real     Test Type      filenameB       60\n"""
                 baseline_filename,
             ),
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
-            '\n\t\tRemove secrets meeting this condition from the codebase,'
-            ' and run detect-secrets scan --update {} to re-scan.\n'.format(
+            '\n\t\tIf any active secrets meet this condition, revoke them.',
+            ' Then, remove them from the codebase and',
+            ' run detect-secrets scan --update {} to re-scan.\n'.format(
                 baseline_filename,
             ),
             'For additional help, run detect-secrets audit --help.\n',
@@ -1072,10 +1073,11 @@ Audited as real     Test Type      filenameB       60\n"""
 
         captured = capsys.readouterr()
 
-        assert captured.out == '\nFailed conditions:\n\n{}\n{}\n{}\n'.format(
+        assert captured.out == '\nFailed conditions:\n\n{}\n{}{}{}\n{}\n'.format(
             colorize('\t- Audited true secrets were found', AnsiColor.BOLD),
-            '\n\t\tRemove secrets meeting this condition from the codebase,'
-            ' and run detect-secrets scan --update {} to re-scan.'.format(
+            '\n\t\tIf any active secrets meet this condition, revoke them.',
+            ' Then, remove them from the codebase and',
+            ' run detect-secrets scan --update {} to re-scan.'.format(
                 baseline_filename,
             ),
             '\nFor additional help, run detect-secrets audit --help.\n',


### PR DESCRIPTION
Before:

```
$ detect-secrets audit --report .secrets.baseline

10 potential secrets in .secrets.baseline were reviewed. Found 2 live secrets, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Private Key              detect_secrets/plugins/private_key.py      49
Live                Hex High Entropy String  docs/scan.md                               49
Unaudited           Private Key              detect_secrets/plugins/private_key.py      52
Audited as real     Hex High Entropy String  docs/audit.md                              83

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit timtest.baseline, and audit all potential secrets.

        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update timtest.baseline to re-scan.

        - Audited true secrets were found

                Remove secrets meeting this condition from the codebase, and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.

```

After:

```
$ detect-secrets audit --report .secrets.baseline

10 potential secrets in .secrets.baseline were reviewed. Found 1 live secret, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Live                Hex High Entropy String  docs/scan.md                               49
Unaudited           Private Key              detect_secrets/plugins/private_key.py      51
Audited as real     Private Key              detect_secrets/plugins/private_key.py      50

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit .secrets.baseline, and audit all potential secrets.

        - Live secrets were found

                Revoke all live secrets and remove them from the codebase. Afterwards, run detect-secrets scan --update .secrets.baseline to re-scan.

        - Audited true secrets were found

               If any active secrets meet this condition, revoke them. Then, remove secrets that were audited as real from the codebase and run detect-secrets scan --update .secrets.baseline to re-scan.

For additional help, run detect-secrets audit --help.
```