### PR TITLE
Fix baseline not found and invalid baseline format error handling

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -1,4 +1,5 @@
 import codecs
+import errno
 import io
 import json
 import os
@@ -345,11 +346,16 @@ def get_secrets_list_from_file(baseline_filename: str) -> list:
 
 def _get_baseline_from_file(filename):  # pragma: no cover
     try:
+        if not os.path.exists(filename):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), filename)
         with open(filename) as f:
             return json.loads(f.read())
+    except (FileNotFoundError):
+        print('File not found: {}'.format(filename), file=sys.stderr)
+        sys.exit(errno.ENOENT)
     except (IOError, json.decoder.JSONDecodeError):
-        print('Not a valid baseline file!', file=sys.stderr)
-        return
+        print('Not a valid baseline file: {}'.format(filename), file=sys.stderr)
+        sys.exit(errno.EIO)
 
 
 def _remove_nonexistent_files_from_baseline(baseline):


### PR DESCRIPTION
## File not found
Before:

```
$ detect-secrets audit --report --fail-on-unaudited nonexisting.baseline
Not a valid baseline file!
Traceback (most recent call last):
  File "/Users/vmiltche/.pyenv/versions/3.8.9/bin/detect-secrets", line 33, in <module>
    sys.exit(load_entry_point('detect-secrets==0.13.1+ibm.47.dss', 'console_scripts', 'detect-secrets')())
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/main.py", line 78, in main
    report.execute(args)
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/report/report.py", line 54, in execute
    (unaudited_return_code, unaudited_secrets) = fail_on_unaudited(
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/report/conditions.py", line 15, in fail_on_unaudited
    secrets = get_secrets_list_from_file(baseline_filename)
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/audit.py", line 341, in get_secrets_list_from_file
    secrets = list(_secret_generator(baseline))
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/audit.py", line 366, in _secret_generator
    for filename, secrets in baseline['results'].items():
TypeError: 'NoneType' object is not subscriptable
```

After:

```
$ detect-secrets audit --report --fail-on-unaudited nonexisting.baseline
File not found: .doesnt.exist
```

## Invalid baseline

Before:

```
$ detect-secrets audit --report --fail-on-unaudited .secrets.baseline
Not a valid baseline file!
Traceback (most recent call last):
  File "/Users/vmiltche/.pyenv/versions/3.8.9/bin/detect-secrets", line 33, in <module>
    sys.exit(load_entry_point('detect-secrets==0.13.1+ibm.47.dss', 'console_scripts', 'detect-secrets')())
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/main.py", line 78, in main
    report.execute(args)
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/report/report.py", line 54, in execute
    (unaudited_return_code, unaudited_secrets) = fail_on_unaudited(
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/report/conditions.py", line 15, in fail_on_unaudited
    secrets = get_secrets_list_from_file(baseline_filename)
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/audit.py", line 341, in get_secrets_list_from_file
    secrets = list(_secret_generator(baseline))
  File "/Users/vmiltche/.pyenv/versions/3.8.9/lib/python3.8/site-packages/detect_secrets/core/audit.py", line 366, in _secret_generator
    for filename, secrets in baseline['results'].items():
TypeError: 'NoneType' object is not subscriptable
```

After:

```
$ detect-secrets audit --report --fail-on-unaudited .secrets.baseline
Not a valid baseline file: .secrets.baseline
```