### PR TITLE
expose 2 redhat ubi containers  

### DIFF
--- a/Dockerfiles/detect-secrets-redhat-ubi/01.detect-secrets-redhat-ubi.Dockerfile
+++ b/Dockerfiles/detect-secrets-redhat-ubi/01.detect-secrets-redhat-ubi.Dockerfile
@@ -7,5 +7,10 @@ COPY detect_secrets /code/detect_secrets
 
 RUN pip install /code
 
-COPY scripts/run-in-pipeline.sh /
+# Ensure no trivy violation for pip
+RUN pip install --upgrade pip
+
 WORKDIR /code
+
+ENTRYPOINT [ "detect-secrets" ]
+CMD [ "scan", "/code" ]

--- a/Dockerfiles/detect-secrets-redhat-ubi/02.detect-secrets-redhat-ubi-custom.Dockerfile
+++ b/Dockerfiles/detect-secrets-redhat-ubi/02.detect-secrets-redhat-ubi-custom.Dockerfile
@@ -1,0 +1,6 @@
+FROM git-defenders/detect-secrets-redhat-ubi
+
+COPY scripts/run-in-pipeline.sh /
+
+ENTRYPOINT [ "/run-in-pipeline.sh" ]
+CMD [ ]

--- a/Dockerfiles/detect-secrets-redhat-ubi/02.detect-secrets-redhat-ubi.Dockerfile
+++ b/Dockerfiles/detect-secrets-redhat-ubi/02.detect-secrets-redhat-ubi.Dockerfile
@@ -1,7 +1,0 @@
-FROM git-defenders/cli-redhat-ubi
-
-# Ensure no trivy violation for pip
-RUN pip install --upgrade pip
-
-ENTRYPOINT [ "/run-in-pipeline.sh" ]
-CMD [ ]

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -19,7 +19,7 @@ DOCKER_REGISTRY_DOCKERHUB := registry.hub.docker.com
 DOCKER_USER_DOCKERHUB := $(DOCKER_HUB_USERNAME)
 DOCKER_PASS_DOCKERHUB := $(DOCKER_HUB_API_KEY)
 
-DOCKER_IMAGES := detect-secrets detect-secrets-hook detect-secrets-redhat-ubi
+DOCKER_IMAGES := detect-secrets detect-secrets-hook detect-secrets-redhat-ubi detect-secrets-redhat-ubi-custom
 DOCKER_REGISTRIES := $(DOCKER_REGISTRY_ART) $(DOCKER_REGISTRY_DOCKERHUB)
 
 IMAGE_NAME :=

--- a/scripts/run-in-pipeline.sh
+++ b/scripts/run-in-pipeline.sh
@@ -33,8 +33,8 @@
 #    FAIL_ON_AUDITED_REAL : (True/False) Sets the condition to fail audit if there are audited and set to real secrets found
 #      * Default:  True
 #
-# Example manual docker run within packaged container (git-defenders/detect-secrets-redhat-ubi):
-#    docker run  --env BASELINE=.secrets.baseline  --env FAIL_ON_LIVE=False  -it -a stdout --rm -v $(pwd):/code git-defenders/detect-secrets-redhat-ubi
+# Example manual docker run within packaged container (git-defenders/detect-secrets-redhat-ubi-custom):
+#    docker run  --env BASELINE=.secrets.baseline  --env FAIL_ON_LIVE=False  -it -a stdout --rm -v $(pwd):/code git-defenders/detect-secrets-redhat-ubi-custom
 ##
 
 ## Constants for FAIL_ON_xx Environment Varibles


### PR DESCRIPTION
expose 2 redhat ubi containers  
- one with custom script entry point 
- one with direct detect-secrets entry point.

detect-secrets-redhat-ubi-custom
```
tefiggins@tefigginss-MacBook-Pro detect-secrets % docker run  -it -a stdout --rm -v $(pwd):/code --env BASELINE=timtest.baseline  --env FAIL-ON-UNAUDITED=TRUE   git-defenders/detect-secrets-redhat-ubi-custom  
[ Starting Detect Secrets run ]

...using baseline: timtest.baseline
...skip scan with baseline update: false
...output json: false
...omit instructions: false
...fail on live: true
...fail on unaudited: true
...fail on audited real: true

Scanning code directory (docker volume mounted to /code) and updating baseline file timtest.baseline ... 

Running report: Baseline timtest.baseline - Options:  --fail-on-live --fail-on-unaudited --fail-on-audited-real


10 potential secrets in timtest.baseline were reviewed. Found 0 live secrets, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Unaudited           Private Key              detect_secrets/plugins/private_key.py      52
Audited as real     Hex High Entropy String  docs/audit.md                              88

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit timtest.baseline, and audit all potential secrets.

        - Audited true secrets were found

                If any active secrets meet this condition, revoke them. Then, remove secrets that were audited as real from the codebase and run detect-secrets scan --update timtest.baseline to re-scan.

For additional help, run detect-secrets audit --help.


[ Ending Detect Secrets - run failed ]
```

detect-secrets-redhat-ubi

```
tefiggins@tefigginss-MacBook-Pro detect-secrets % docker run  -it -a stdout --rm -v $(pwd):/code  git-defenders/detect-secrets-redhat-ubi audit --report  --fail-on-unaudited --fail-on-audited-real  --fail-on-live  timtest.baseline

10 potential secrets in timtest.baseline were reviewed. Found 0 live secrets, 1 unaudited secret and 1 secret that was audited as real.

Failed Condition    Secret Type              Filename                                 Line
------------------  -----------------------  -------------------------------------  ------
Unaudited           Private Key              detect_secrets/plugins/private_key.py      52
Audited as real     Hex High Entropy String  docs/audit.md                              88

Failed conditions:

        - Unaudited secrets were found

                Run detect-secrets audit timtest.baseline, and audit all potential secrets.

        - Audited true secrets were found

                If any active secrets meet this condition, revoke them. Then, remove secrets that were audited as real from the codebase and run detect-secrets scan --update timtest.baseline to re-scan.

For additional help, run detect-secrets audit --help.

tefiggins@tefigginss-MacBook-Pro detect-secrets %
```