### PR TITLE
Base on UBI minimal image with python38 added vs python39 UBI

### DIFF
--- a/Dockerfiles/base/00.python-redhat-ubi.Dockerfile
+++ b/Dockerfiles/base/00.python-redhat-ubi.Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi8-minimal
 LABEL maintainer="squad:git-defenders" url="https://github.ibm.com/whitewater/whitewater-detect-secrets"
 
 User root
-RUN yum -y update
+# install python 3.9 and corresponding pip ... install git (used in DS scan)
+RUN microdnf -y install python39 python39-pip git
+RUN microdnf -y update

--- a/Dockerfiles/base/00.python-redhat-ubi.Dockerfile
+++ b/Dockerfiles/base/00.python-redhat-ubi.Dockerfile
@@ -2,6 +2,6 @@ FROM registry.access.redhat.com/ubi8-minimal
 LABEL maintainer="squad:git-defenders" url="https://github.ibm.com/whitewater/whitewater-detect-secrets"
 
 User root
-# install python 3.9 and corresponding pip ... install git (used in DS scan)
-RUN microdnf -y install python39 python39-pip git
+# install python 3.8 and corresponding pip ... install git (used in DS scan)
+RUN microdnf -y install python38 python38-pip git
 RUN microdnf -y update

--- a/Dockerfiles/detect-secrets/01.detect-secrets-redhat-ubi.Dockerfile
+++ b/Dockerfiles/detect-secrets/01.detect-secrets-redhat-ubi.Dockerfile
@@ -5,10 +5,7 @@ COPY setup.py /code/
 COPY setup.cfg /code/
 COPY detect_secrets /code/detect_secrets
 
-RUN pip install /code
-
-# Ensure no trivy violation for pip
-RUN pip install --upgrade pip
+RUN pip3 install /code
 
 WORKDIR /code
 


### PR DESCRIPTION
For pipelines the desire is to have all containers base on UBI. Detect Secrets is a python project and thus we use the python39 tagged UBI image. Once pushed to ICR, ICR scans showed some config issues with mysql and apache (note: we don't use either).

The PR is to redo the DS UBI containers and start with UBI-minimal and add python38 (ALSO going to python38 since the one with auto UT testcases) and git (used by scan process) to the image. Thus having the most minimalistic container necessary to run the Detect Secrets scans and reporting.

Note UBI-minimal does not have yum command like UBI-standard-- must use: microdnf command