### PR TITLE
Update Doc for image Versioning

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -234,7 +234,7 @@ Users can reference a specific version of the detect-secrets redhat-ubi-tagged i
 - This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based detect secrets image.
 
 `ibmcom/detect-secrets:redhat-ubi-custom`
-- This tag will be considered as the `"latest"` version for the redhat-ubi based custom Detect Secrets image.
+- This will be considered the `latest` version for the image.
 
 `ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi-custom`
 - This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based custom detect secrets image.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -228,7 +228,7 @@ To use the image in your pipeline, add the following commands to your pipeline s
 Users can reference a specific version of the detect-secrets redhat-ubi-tagged images. That way one can peg to the specific version for these images as we release newer versions of them instead of using the "latest" version.
 
 `ibmcom/detect-secrets:redhat-ubi`
-- This tag will be considered as the `"latest"` version for the redhat-ubi based detect secrets image.
+- This will be considered the `latest` version for the image.
 
 `ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi`
 - This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based detect secrets image.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -224,6 +224,20 @@ To use the image in your pipeline, add the following commands to your pipeline s
 2. Mount the directory containing your code to the Docker image's `/code` folder, since it's the working directory for detect-secrets. The image will automatically update your baseline file and run a report against it:
     - `docker run -it -a stdout --rm -v $(pwd):/code ibmcom/detect-secrets:redhat-ubi-custom`
 
+#### Image Versioning:
+Users can reference a specific version of the detect-secrets redhat-ubi-tagged images. That way one can peg to the specific version for these images as we release newer versions of them instead of using the "latest" version.
+
+`ibmcom/detect-secrets:redhat-ubi`
+- This tag will be considered as the `"latest"` version for the redhat-ubi based detect secrets image.
+
+`ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi`
+- This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based detect secrets image.
+
+`ibmcom/detect-secrets:redhat-ubi-custom`
+- This tag will be considered as the `"latest"` version for the redhat-ubi based custom Detect Secrets image.
+
+`ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi-custom`
+- This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based custom detect secrets image.
 #### Installing via pip
 
 ##### Travis

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -231,7 +231,7 @@ Users can reference a specific version of the detect-secrets redhat-ubi-tagged i
 - This will be considered the `latest` version for the image.
 
 `ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi`
-- This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based detect secrets image.
+- This one will allow users to lock the image to a specific Detect Secrets version, in this case `0.13.1.ibm.48.dss`.
 
 `ibmcom/detect-secrets:redhat-ubi-custom`
 - This will be considered the `latest` version for the image.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -237,7 +237,7 @@ Users can reference a specific version of the detect-secrets redhat-ubi-tagged i
 - This will be considered the `latest` version for the image.
 
 `ibmcom/detect-secrets:0.13.1.ibm.48.dss-redhat-ubi-custom`
-- This one will allow users to peg themselves to the specific version, `0.13.1.ibm.48.dss`, of the redhat-ubi based custom detect secrets image.
+- This will allow users to lock the image to a specific Detect Secrets version, in this case `0.13.1.ibm.48.dss`.
 #### Installing via pip
 
 ##### Travis

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -224,7 +224,7 @@ To use the image in your pipeline, add the following commands to your pipeline s
 2. Mount the directory containing your code to the Docker image's `/code` folder, since it's the working directory for detect-secrets. The image will automatically update your baseline file and run a report against it:
     - `docker run -it -a stdout --rm -v $(pwd):/code ibmcom/detect-secrets:redhat-ubi-custom`
 
-#### Image Versioning:
+#### Image Versioning
 Users can reference a specific version of the detect-secrets redhat-ubi-tagged images. That way one can peg to the specific version for these images as we release newer versions of them instead of using the "latest" version.
 
 `ibmcom/detect-secrets:redhat-ubi`


### PR DESCRIPTION
Information Update:  Users can reference a specific version of the detect-secrets redhat-ubi-tagged images. 