### PR TITLE
Widen the slack secret regex to future-proof and capture older webhooks

### DIFF
--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -19,7 +19,7 @@ class SlackDetector(RegexBasedDetector):
         # Slack Webhooks
         re.compile(
             r"""
-            https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,10}/[a-zA-Z0-9_]{24}
+            https://hooks.slack.com/services/T[a-zA-Z0-9_]+/B[a-zA-Z0-9_]+/[a-zA-Z0-9_]+
             """,
             flags=re.IGNORECASE | re.VERBOSE,
         ),

--- a/tests/plugins/slack_test.py
+++ b/tests/plugins/slack_test.py
@@ -36,6 +36,9 @@ class TestSlackDetector:
             (
                 'https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx'
             ),
+            (
+                'https://hooks.slack.com/services/Txxxxxxxxxx/Bxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx'
+            ),
         ],
     )
     def test_analyze(self, file_content):


### PR DESCRIPTION
The existing regex for detecting Slack webhooks is locked to the [current format](https://api.slack.com/messaging/webhooks) and doesn't capture an older webhook of the form `https://hooks.slack.com/services/T........../B........../........................` (e.g. 10 characters following the `T` rather than 8)

This PR changes the Slack regex to match [upstream](https://github.com/Yelp/detect-secrets/blob/e8426a428ef60f32193a02d0f1c2c1636336d63d/detect_secrets/plugins/slack.py#L24) where the number of characters in each part of the URL is simply 1 or more.

This will also guard against future Slack updates (they've already done it once 😉)