### PR TITLE
Replace safety check with Trivy Python package scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '18 1 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 deploy:
     - provider: script
       script: >-
-          set -e; make docker-build-images docker-test-images setup-trivy docker-quality-images deploy
+          set -e; make docker-build-images docker-test-images docker-quality-images deploy
       on:
           all_branches: true
           # only build docker image and push once
@@ -21,9 +21,9 @@ matrix:
         # - env: TOXENV=py35
         #   python: 3.5
         - env: TOXENV=py36
-          python: 3.6.10 # We're targeting a specific patch version; if set to 3.6, the GitHub Travis build will use Python 3.6.7 and will fail due to a cryptography installation error
+          python: 3.6.15 # We're targeting a specific patch version; if set to 3.6, the GitHub Travis build will use Python 3.6.7 and will fail due to a cryptography installation error
         - env: TOXENV=py37
-          python: 3.7.11
+          python: 3.7.13
           dist: xenial # Required for Python >= 3.7 (travis-ci/travis-ci#9069), the GitHub Travis build will use Python 3.7.1 by default if you provide 3.7 without a patch version and the build will fail with AttributeError: 'str' object has no attribute 'name'
         - env: TOXENV=py38
           python: 3.8
@@ -34,8 +34,8 @@ before_install:
     - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
     - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub Enterprise
 install:
-    - pip install tox
-script: make test
+    - pip install tox pipenv
+script: make setup-trivy && make trivy-scan-python-vulnerabilities && make test
 cache:
     directories:
         - $HOME/.cache/pre-commit

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -53,13 +53,12 @@ setup-trivy:
 	curl -sSfL https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_$(TRIVY_OS)-$(TRIVY_ARCH)bit.tar.gz -o /tmp/trivy.tar.gz
 	tar zxvf /tmp/trivy.tar.gz -C $(dir $(TRIVY)) trivy
 
-
-
 trivy-scan-python-vulnerabilities:
-	# First, Generate a Pipfile.lock, Trivy does not auto-detect requirements-dev.txt (https://aquasecurity.github.io/trivy/v0.28.1/docs/vulnerability/detection/language/)
+	PIPENV_YES=True # If set, Pipenv automatically assumes “yes” at all prompts. This prevents the build from hanging.
+	PIPENV_IGNORE_VIRTUALENVS=True # Forces Pipenv to ignore the existing virtual environment and create its own instead
+
+	# Generate a Pipfile.lock, Trivy does not auto-detect requirements-dev.txt (https://aquasecurity.github.io/trivy/v0.28.1/docs/vulnerability/detection/language/)
 	./scripts/gen-pipfile.sh > Pipfile
-	export PIPENV_YES=True # If set, Pipenv automatically assumes “yes” at all prompts. This prevents the build from hanging.
-	export PIPENV_IGNORE_VIRTUALENVS=True # Forces Pipenv to ignore the existing virtual environment and create its own instead
 	pipenv --python `which python3`
 	pipenv lock
 	$(TRIVY) fs --exit-code 1 --ignore-unfixed --security-checks vuln ./

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -53,6 +53,17 @@ setup-trivy:
 	curl -sSfL https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_$(TRIVY_OS)-$(TRIVY_ARCH)bit.tar.gz -o /tmp/trivy.tar.gz
 	tar zxvf /tmp/trivy.tar.gz -C $(dir $(TRIVY)) trivy
 
+
+
+trivy-scan-python-vulnerabilities:
+	# First, Generate a Pipfile.lock, Trivy does not auto-detect requirements-dev.txt (https://aquasecurity.github.io/trivy/v0.28.1/docs/vulnerability/detection/language/)
+	./scripts/gen-pipfile.sh > Pipfile
+	export PIPENV_YES=True # If set, Pipenv automatically assumes “yes” at all prompts. This prevents the build from hanging.
+	export PIPENV_IGNORE_VIRTUALENVS=True # Forces Pipenv to ignore the existing virtual environment and create its own instead
+	pipenv --python `which python3`
+	pipenv lock
+	$(TRIVY) fs --exit-code 1 --ignore-unfixed --security-checks vuln ./
+
 docker-quality-images:
 	for image_name in $(DOCKER_IMAGES_TO_SCAN) ; do												\
 		$(TRIVY) image --exit-code 1 --ignore-unfixed $(DOCKER_DOMAIN_LOCAL)/$*$${image_name};  \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-# coveragepy==5.0 fails with `Safety level may not be changed inside a transaction
 # on python 3.6.0 (xenial)
 pip>=21.1
 urllib3>=1.26.4
@@ -17,5 +16,4 @@ responses
 ibm_db
 boxsdk[jwt]
 pyahocorasick
-safety
 tabulate

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,9 @@ skip_missing_interpreters = true
 # tox_pip_extensions_ext_venv_update = true
 
 [testenv]
-passenv = SSH_AUTH_SOCK SAFETY_API_KEY
 deps = -rrequirements-dev.txt
 whitelist_externals = coverage
 commands =
-    safety check
     coverage erase
     coverage run -m pytest tests
     coverage report --show-missing --include=tests/* --fail-under 100


### PR DESCRIPTION
Replaces `safety` check with `trivy`'s filesystem vulnerability scan. Trivy will detect a Pip package lockfile, which we generate via a script. We have to do this because Trivy does not auto-detect `requirements-dev.txt` (see https://aquasecurity.github.io/trivy/v0.28.1/docs/vulnerability/detection/language/ for a list of auto-detected language-specific files).

Also fixes pre-commit errors with `.github/workflows/codeql-analysis.yml`.