### PR TITLE
adding example for exclude-files in developer-tool-faq.md

### DIFF
--- a/docs/developer-tool-faq.md
+++ b/docs/developer-tool-faq.md
@@ -253,8 +253,9 @@ If the false positive hits are overwhelming, you can tune the tool in several wa
 Detect Secrets supports regex-based file and folder exclusions. The excludes file list will be recorded in the outputted baseline file. In future scans, if no `--exclude-files` option is provided, the existing exclude list in the baseline file will be respected. If a new exclude list is supplied through the command line, it will overwrite the existing exclude list in the baseline file.
 
 ```sh
-detect-secrets scan --exclude-files '<folder_to_ignore>|<file_to_ignore>'
+detect-secrets scan --update .secrets.baseline --exclude-files '<folder_to_ignore>|<file_to_ignore>'
 ```
+Example: `detect-secrets scan --update .secrets.baseline --exclude-files "package-lock.json"`
 
 #### Tune the threshold for the entropy based scanner
 


### PR DESCRIPTION
I did try to use detect-secret and exclude my package-lock.json file . However, that command did not help me achieve that as it was missing `--update` flag. After talking to the team, I realized I need to add that flag to the command and thus creating a PR which has the flag updated in sh command and also an example that can help adopters know how to easily exclude files while using detect-secret.