### PR TITLE
Tweak base Dockerfiles

### DIFF
--- a/Dockerfiles/base/00.python.Dockerfile
+++ b/Dockerfiles/base/00.python.Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3
 LABEL maintainer="squad:git-defenders" url="https://github.com/IBM/detect-secrets"
 
-RUN apt-get -y remove --purge mysql*
-RUN apt-get update && apt-get upgrade -y
-RUN pip install --upgrade pip
+RUN \
+  apt-get update && \
+  apt-get -y remove --purge mysql* && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/* && \
+  pip install --upgrade pip

--- a/Dockerfiles/base/01.cli.Dockerfile
+++ b/Dockerfiles/base/01.cli.Dockerfile
@@ -1,15 +1,13 @@
 FROM git-defenders/python
 
-# Auto adjust line ending. Support running scan on Windows platform
-RUN git config --system core.autocrlf true
-# Improve performace when creating index across Windows and Linux platform
-RUN git config --system core.checkStat minimal
+RUN \
+  # Auto adjust line ending. Support running scan on Windows platform
+  git config --system core.autocrlf true && \
+  # Improve performace when creating index across Windows and Linux platform
+  git config --system core.checkStat minimal
 
-COPY README.md /code/
-COPY setup.py /code/
-COPY setup.cfg /code/
+COPY setup.py setup.cfg /code/
 COPY detect_secrets /code/detect_secrets
-
 RUN pip install /code
 
 # Generate pipenv lock file under /, it will be picked up by trivy


### PR DESCRIPTION
I think these are the `Dockerfile`s for an image that I use a lot and that is pulled a lot. And I saw that one of those images comes with a lot of layers, so I had a look.

To the best of my knowledge, there is no real penalty to lots of layers in container images anymore. Still, a lot of smaller layers can make a overall pull operation slower on average.

Therefore, I had a look and think we can tweak at least the layers that we contribute in the respective `Dockerfile`s. It is basically putting together commands that belong together anyway, plus removing the README file from the image as I believe nobody will probably read it in there. What do you think?