### PR TITLE
Fix version check: temporarily hardcode COS IP

### DIFF
--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.55.dss'
+VERSION = '0.13.1+ibm.56.dss'

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -41,8 +41,7 @@ def version_check():
                 end_yellow,
                 file=sys.stderr,
             )
-    except Exception as e:
-        print(e)
+    except Exception:
         print(
             yellow +
             'Failed to check for newer version of detect-secrets.\n' +

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -17,10 +17,15 @@ def version_check():
     try:
         resp = requests.get(
             (
-                'https://detect-secrets-client-version.s3.us-south.'
-                'cloud-object-storage.appdomain.cloud/version'
+                # We need to hard-code the Cloud Object Storage service IP address
+                # since using the full URL results in on-and-off certificate errors.
+                # TODO: revert back to using https://detect-secrets-client-version.s3
+                # .us-south.cloud-object-storage.appdomain.cloud/version
+                # once cert issues are fixed by IBM Cloud.
+                'https://169.46.118.100/detect-secrets-client-version/version'
             ),
             timeout=5,  # added for COS timeout
+            verify=False,  # TODO: remove this line once COS cert issues are fixed
         )
         resp.raise_for_status()
         latest_version = parse(resp.text)
@@ -36,7 +41,8 @@ def version_check():
                 end_yellow,
                 file=sys.stderr,
             )
-    except Exception:
+    except Exception as e:
+        print(e)
         print(
             yellow +
             'Failed to check for newer version of detect-secrets.\n' +

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,8 +31,12 @@ def test_version_check_out_of_date():
     responses.add(
         responses.GET,
         (
-            'https://detect-secrets-client-version.s3.us-south.'
-            'cloud-object-storage.appdomain.cloud/version'
+            # We need to hard-code the Cloud Object Storage service IP address
+            # since using the full URL results in on-and-off certificate errors.
+            # TODO: revert back to using https://detect-secrets-client-version.s3
+            # .us-south.cloud-object-storage.appdomain.cloud/version
+            # once cert issues are fixed by IBM Cloud.
+            'https://169.46.118.100/detect-secrets-client-version/version'
         ),
         status=200,
         body='1000000.0.0+ibm.0',
@@ -53,8 +57,12 @@ def test_version_check_not_out_of_date():
     responses.add(
         responses.GET,
         (
-            'https://detect-secrets-client-version.s3.us-south.'
-            'cloud-object-storage.appdomain.cloud/version'
+            # We need to hard-code the Cloud Object Storage service IP address
+            # since using the full URL results in on-and-off certificate errors.
+            # TODO: revert back to using https://detect-secrets-client-version.s3
+            # .us-south.cloud-object-storage.appdomain.cloud/version
+            # once cert issues are fixed by IBM Cloud.
+            'https://169.46.118.100/detect-secrets-client-version/version'
         ),
         status=200,
         body=VERSION,
@@ -70,9 +78,14 @@ def test_version_check_not_out_of_date():
 def test_verion_check_latest_version_request_fails():
     responses.add(
         responses.GET,
+        responses.GET,
         (
-            'https://detect-secrets-client-version.s3.us-south.'
-            'cloud-object-storage.appdomain.cloud/version'
+            # We need to hard-code the Cloud Object Storage service IP address
+            # since using the full URL results in on-and-off certificate errors.
+            # TODO: revert back to using https://detect-secrets-client-version.s3
+            # .us-south.cloud-object-storage.appdomain.cloud/version
+            # once cert issues are fixed by IBM Cloud.
+            'https://169.46.118.100/detect-secrets-client-version/version'
         ),
         status=404,
     )


### PR DESCRIPTION
The ` https://detect-secrets-client-version.s3.us-south.cloud-object-storage.appdomain.cloud/version` URL is resulting in on-and-off certificate issues which causes the Detect Secrets version check to fail:

```bash
detect-secrets scan --update .secrets.baseline 
Failed to check for newer version of detect-secrets.

# . . .
```

IBM Cloud support is aware of this issue and are working on a fix. They recommended that in the meantime, we hard-code the IP address since it does not result in these errors: `https://169.46.118.100/detect-secrets-client-version/version`.

Once the COS certificate errors are fixed, we can revert these changes.