### PR TITLE
Add `--no-version-check` flag

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -68,7 +68,8 @@ class ParserBuilder(object):
             ._add_use_all_plugins_argument()\
             ._add_no_verify_flag()\
             ._add_output_verified_false_flag()\
-            ._add_fail_on_unaudited_flag()
+            ._add_fail_on_unaudited_flag()\
+            ._add_no_version_check_flag()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -150,6 +151,14 @@ class ParserBuilder(object):
             '--fail-on-unaudited',
             action='store_true',
             help='Fail check if there are entries have not been audited in baseline.',
+        )
+        return self
+
+    def _add_no_version_check_flag(self):
+        self.parser.add_argument(
+            '--no-version-check',
+            action='store_true',
+            help='Skip update of local tool version in baseline when there are no new secrets.',
         )
         return self
 

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -89,7 +89,8 @@ def main(argv=None):
 
     if VERSION != baseline_collection.version:
         baseline_collection.version = VERSION
-        baseline_modified = True
+        if not args.no_version_check:
+            baseline_modified = True
 
     if baseline_modified:
         write_baseline_to_file(

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -116,7 +116,7 @@ def test_build_automaton():
         ('1.0.0+ibm.5', '1.0.0+ibm.5.dss'),
         ('1.0.0+ibm.5.dss', '1.0.0+ibm.6.dss'),
         ('1.0.0+ibm.5.dss', '1.0.0+ibm.6.dss.1'),
-        ('0.13.0-ibm.6-dss', '0.13.0+ibm.7.dss'),
+        ('0.13.0+ibm.6-dss', '0.13.0+ibm.7.dss'),
     ],
 )
 def test_version_compare(smaller_version_txt, larger_version_txt):


### PR DESCRIPTION
Currently whenever a local tool version doesn't match the version in a baseline file the developers are forced to update it even when there are no secrets change. Together with an updated timestamp this creates a constant merge conflict problems when multiple developers are working in parallel.

This change adds a new flag `--no-version-check` that allows to skip the version update in the baseline file when there are no other changes.

The new flag is false by default, allowing to keep back compatibility with the previous behaviour.


An additional small update in `util_test.py` addresses the fact that `packaging` dropped support for `LegacyVersion` in [version 0.22](https://github.com/pypa/packaging/releases/tag/22.0), so `test_version_compare` tests are now failing on the old version parameter with an invalid format exception.