### PR TITLE
Removing dockerhub references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # You are encouraged to use static refs such as tags, instead of branch name
       #
       # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-      rev: 0.13.1+ibm.50.dss
+      rev: 0.13.1+ibm.55.dss
       hooks:
           - id: detect-secrets # pragma: whitelist secret
             # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-08-26T14:38:39Z",
+  "generated_at": "2022-12-19T16:41:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -160,7 +160,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.50.dss",
+  "version": "0.13.1+ibm.55.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
     - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub Enterprise
 install:
-    - pip install tox pipenv
+    - pip install "certifi>=2022.12.07" tox pipenv
 script: make setup-trivy && make trivy-scan-python-vulnerabilities && make test
 cache:
     directories:

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -5,7 +5,6 @@ MAKEFLAGS += --warn-undefined-variables
 DEBUG_IMAGE_TAG := $(TRAVIS_BRANCH)-$(TRAVIS_BUILD_NUMBER)-id-$(TRAVIS_BUILD_ID)-time-$(shell date +%s)
 
 DOCKER_DOMAIN := git-defenders
-DOCKERHUB_DOMAIN := ibmcom
 
 DOCKER_REGISTRY_ICR := icr.io
 DOCKER_USER_ICR := iamapikey

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -15,14 +15,10 @@ DOCKER_REGISTRY_ART := txo-toolbox-team-docker-local.artifactory.swg-devops.com
 DOCKER_USER_ART := $(ART_USER_ID)
 DOCKER_PASS_ART := $(ART_API_KEY)
 
-DOCKER_REGISTRY_DOCKERHUB := registry.hub.docker.com
-DOCKER_USER_DOCKERHUB := $(DOCKER_HUB_USERNAME)
-DOCKER_PASS_DOCKERHUB := $(DOCKER_HUB_API_KEY)
-
 DOCKER_IMAGES_TO_TAG := detect-secrets detect-secrets-hook
 DOCKER_IMAGES_TO_SCAN := detect-secrets detect-secrets-hook detect-secrets:redhat-ubi detect-secrets:redhat-ubi-custom
 DOCKER_IMAGES_TO_PUBLISH :=
-DOCKER_REGISTRIES := $(DOCKER_REGISTRY_ICR) $(DOCKER_REGISTRY_ART) $(DOCKER_REGISTRY_DOCKERHUB)
+DOCKER_REGISTRIES := $(DOCKER_REGISTRY_ICR) $(DOCKER_REGISTRY_ART)
 
 IMAGE_NAME :=
 DOCKER_REGISTRY :=
@@ -84,7 +80,6 @@ docker-build-images:
 	done
 
 docker-login:
-	@echo $(DOCKER_PASS_DOCKERHUB) | docker login -u $(DOCKER_USER_DOCKERHUB) --password-stdin;
 	@echo $(DOCKER_PASS_ART) | docker login -u $(DOCKER_USER_ART) --password-stdin $(DOCKER_REGISTRY_ART);
 	@echo $(DOCKER_PASS_ICR) | docker login -u $(DOCKER_USER_ICR) --password-stdin $(DOCKER_REGISTRY_ICR);
 
@@ -111,13 +106,8 @@ docker-publish-images: docker-login
 	done
 
 docker-publish-image:
-	if [ "$(DOCKER_REGISTRY)" = "$(DOCKER_REGISTRY_DOCKERHUB)" ]; then                                     \
-		docker tag $(DOCKER_DOMAIN_LOCAL)/$(IMAGE_NAME) $(DOCKERHUB_DOMAIN)/$(IMAGE_NAME);                 \
-		docker push $(DOCKERHUB_DOMAIN)/$(IMAGE_NAME); 													   \
-	else                                                                                                   \
-		docker tag $(DOCKER_DOMAIN_LOCAL)/$(IMAGE_NAME) $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(IMAGE_NAME); \
-		docker push $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(IMAGE_NAME);									   \
-	fi
+	docker tag $(DOCKER_DOMAIN_LOCAL)/$(IMAGE_NAME) $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(IMAGE_NAME); \
+	docker push $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(IMAGE_NAME);
 
 publish-cos:
 	pip install requests packaging;                                                                                 \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 pip>=21.1
 urllib3>=1.26.4
 coverage>=6.0b1
+certifi>=2022.12.07
 flake8
 mock
 monotonic
@@ -12,7 +13,6 @@ responses
 tox-pip-extensions
 tox>=3.8
 unidiff
-responses
 ibm_db
 boxsdk[jwt]
 pyahocorasick

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -116,7 +116,7 @@ def test_build_automaton():
         ('1.0.0+ibm.5', '1.0.0+ibm.5.dss'),
         ('1.0.0+ibm.5.dss', '1.0.0+ibm.6.dss'),
         ('1.0.0+ibm.5.dss', '1.0.0+ibm.6.dss.1'),
-        ('0.13.0-ibm.6-dss', '0.13.0+ibm.7.dss'),
+        ('0.13.0+ibm.6.dss', '0.13.0+ibm.7.dss'),
     ],
 )
 def test_version_compare(smaller_version_txt, larger_version_txt):

--- a/user-config/detect-secrets.psm1
+++ b/user-config/detect-secrets.psm1
@@ -14,7 +14,7 @@
 function detect-secrets {
     $current_dir = (Get-Location).Path
     $dss_image_tag = "dss-latest"
-    $dss_image = "ibmcom/detect-secrets:${dss_image_tag}"
+    $dss_image = "icr.io/git-defenders/detect-secrets:${dss_image_tag}"
 
     docker run --rm -it -v ${current_dir}:/code ${dss_image} $args
 }


### PR DESCRIPTION
IBMCOM is being removed from DockerHub. This removes references to the DockerHub image of Detect Secrets, replacing it with references to IBM's ICR. 

* Updates vulnerable package