### PR TITLE
pre-commit migrate-config

### DIFF
--- a/user-config/.pre-commit-config.yaml
+++ b/user-config/.pre-commit-config.yaml
@@ -4,13 +4,14 @@
 # Read pre-commit hook framework https://pre-commit.com/ for more details about the structure of config yaml file and how git pre-commit would invoke each hook.
 #
 # This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
-- repo: https://github.com/ibm/detect-secrets
-  # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-  # You are encouraged to use static refs such as tags, instead of branch name
-  #
-  # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: master
-  hooks:
+repos:
+  - repo: https://github.com/ibm/detect-secrets
+    # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
+    # You are encouraged to use static refs such as tags, instead of branch name
+    #
+    # Running "pre-commit autoupdate" would automatically updates rev to latest tag
+    rev: master
+    hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.
         # You may also run `pre-commit run detect-secrets` to preview the scan result.


### PR DESCRIPTION
This PR migrates the detect secrets pre-commit config intended for users.

Resolves this warning:
```
> pre-commit install
[WARNING] normalizing pre-commit configuration to a top-level map. support for top level list will be removed in a future version. run: `pre-commit migrate-config` to automatically fix this.
[WARNING] The 'rev' field of repo 'https://github.com/ibm/detect-secrets' appears to be a mutable reference (moving tag / branch). Mutable references are never updated after first install and are not supported. See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details. Hint: `pre-commit autoupdate` often fixes this.
pre-commit installed at .git/hooks/pre-commit
```