### PR TITLE
Use latest version tag rather than branch name for user pre-commit file rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # You are encouraged to use static refs such as tags, instead of branch name
       #
       # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-      rev: 0.13.1+ibm.55.dss
+      rev: 0.13.1+ibm.56.dss
       hooks:
           - id: detect-secrets # pragma: whitelist secret
             # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-12-19T16:41:15Z",
+  "generated_at": "2023-01-31T20:56:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -160,7 +160,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.55.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/update.md
+++ b/update.md
@@ -61,6 +61,7 @@ Format: `<upstream-version>-ibm.<minor>.<fix>`, for example `0.12.0-ibm.3`
 1. When fixing IBM specific bugs, increase `<fix>`
 1. When rebase from upstream, update `<upstream-version>` to the rebased upstream version. We do not reset the `<minor>` and `<fix>` when bumping upstream version.
 1. Version number also needs to be updated in [`__init__.py`](./detect_secrets/__init__.py#L1)
+1. Update the version number (value of `rev`) in [`user-config/.pre-commit-config.yaml`](./user-config/.pre-commit-config.yaml)
 
 ## How do we make release
 

--- a/user-config/.pre-commit-config.yaml
+++ b/user-config/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
     # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
     # You are encouraged to use static refs such as tags, instead of branch name
     #
-    # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-    rev: master
+    # Running "pre-commit autoupdate" automatically updates rev to latest tag
+    rev: 0.13.1+ibm.56.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.


### PR DESCRIPTION
Using a branch name as the pre-commit config `rev` such as `master` isn’t supported by [pre-commit](https://pre-commit.com/). I ran `pre-commit autoupdate`, which is the solution recommended by `pre-commit`.

This is the warning I get when using the pre-commit config from our codebase (note that it’s using a super old version of DS):
```
[WARNING] The 'rev' field of repo 'https://github.com/ibm/detect-secrets' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
Detect secrets...........................................................Failed
- hook id: detect-secrets
- exit code: 1

WARNING: You are running an outdated version of detect-secrets.
 Your version: 0.13.1+ibm.22.dss
 Latest version: 0.13.1+ibm.56.dss
 See upgrade guide at https://ibm.biz/detect-secrets-how-to-upgrade

Error: No such `AzureStorageKeyDetector` plugin to initialize.
Chances are you should run `pre-commit autoupdate`.
This error occurs when using a baseline that was made by a newer detect-secrets version than the one running.
```

Explanation from the [`pre-commit` docs](https://pre-commit.com/#using-the-latest-version-for-a-repository):

> Using the latest version for a repository

> pre-commit configuration aims to give a repeatable and fast experience and therefore intentionally doesn't provide facilities for "unpinned latest version" for hook repositories.

> Instead, pre-commit provides tools to make it easy to upgrade to the latest versions with pre-commit autoupdate. If you need the absolute latest version of a hook (instead of the latest tagged version), pass the --bleeding-edge parameter to autoupdate.

> pre-commit assumes that the value of rev is an immutable ref (such as a tag or SHA) and will cache based on that. Using a branch name (or HEAD) for the value of rev is not supported and will only represent the state of that mutable ref at the time of hook installation (and will NOT update automatically).

So, in the pre-commit file intended to be copied over by users, the rev should actually be set to the latest detect-secrets version rather than `master`.