### PR TITLE
Make /tmp/cosign executable

### DIFF
--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -53,7 +53,8 @@ setup-trivy:
 	tar zxvf /tmp/trivy.tar.gz -C $(dir $(TRIVY)) trivy
 
 setup-cosign:
-	curl -sSfL https://github.com/sigstore/cosign/releases/download/v$(COSIGN_VERSION)/cosign-linux-amd64  -o /tmp/cosign
+	curl -sSfL https://github.com/sigstore/cosign/releases/download/v$(COSIGN_VERSION)/cosign-linux-amd64  -o $COSIGN
+	chmod +x $COSIGN
 
 trivy-scan-python-vulnerabilities:
 	PIPENV_YES=True # If set, Pipenv automatically assumes “yes” at all prompts. This prevents the build from hanging.

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -53,8 +53,8 @@ setup-trivy:
 	tar zxvf /tmp/trivy.tar.gz -C $(dir $(TRIVY)) trivy
 
 setup-cosign:
-	curl -sSfL https://github.com/sigstore/cosign/releases/download/v$(COSIGN_VERSION)/cosign-linux-amd64  -o $COSIGN
-	chmod +x $COSIGN
+	curl -sSfL https://github.com/sigstore/cosign/releases/download/v$(COSIGN_VERSION)/cosign-linux-amd64  -o $(COSIGN)
+	chmod +x $(COSIGN)
 
 trivy-scan-python-vulnerabilities:
 	PIPENV_YES=True # If set, Pipenv automatically assumes “yes” at all prompts. This prevents the build from hanging.


### PR DESCRIPTION
Fixes this error:
```bash
/bin/bash: line 1: /tmp/cosign: Permission denied
```