### PR TITLE
Peg requests (new version is broken), and update urllib3 in requirements-dev

### DIFF
--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.59.dss'
+VERSION = '0.13.1+ibm.60.dss'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pip>=21.1
-urllib3>=1.26.4
+urllib3==1.26.15
 coverage>=6.0b1
 certifi>=2022.12.07
 flake8

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords=['secret-management', 'pre-commit', 'security', 'entropy-checks'],
     install_requires=[
         'pyyaml',
-        'requests',
+        'requests==2.29.0',  # requests v2.30.0 is broken
         'boxsdk[jwt]',
         'packaging',
         'tabulate',


### PR DESCRIPTION
Since the `requests` `v2.30.0` package appears to be broken, I've pegged `requests` to the previous version. I've also bumped the version of `urllib3` used for local development to the version which comes with `requests` `v2.29.0`.