### PR TITLE
chore: Unpin requests dep, pin urllib3 dep

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-25T14:27:52Z",
+  "generated_at": "2023-05-25T14:44:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.58.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-24T21:27:43Z",
+  "generated_at": "2023-05-25T14:27:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.58.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.60.dss'
+VERSION = '0.13.1+ibm.61.dss'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pip>=21.1
-urllib3>=1.26.15
+urllib3<2.0.0
 coverage>=6.0b1
 certifi>=2022.12.07
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pip>=21.1
-urllib3==1.26.15
+urllib3>=1.26.15
 coverage>=6.0b1
 certifi>=2022.12.07
 flake8

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     install_requires=[
         'pyyaml',
         'requests',
+        'urllib3<2.0.0',
         'boxsdk[jwt]',
         'packaging',
         'tabulate',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords=['secret-management', 'pre-commit', 'security', 'entropy-checks'],
     install_requires=[
         'pyyaml',
-        'requests==2.29.0',  # requests v2.30.0 is broken
+        'requests',
         'boxsdk[jwt]',
         'packaging',
         'tabulate',

--- a/user-config/.pre-commit-config.yaml
+++ b/user-config/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     # You are encouraged to use static refs such as tags, instead of branch name
     #
     # Running "pre-commit autoupdate" automatically updates rev to latest tag
-    rev: 0.13.1+ibm.60.dss
+    rev: 0.13.1+ibm.61.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.


### PR DESCRIPTION
# Info

Unpins the requests dependency, but adds a pinned urllib3 dependency. Upstream requests says ["this isn't a requests problem, its a how you're getting urllib3 problem"](https://github.com/psf/requests/issues/6443); Also - [CVE-2023-32681](https://github.com/advisories/GHSA-j8r2-6x86-q33q) is getting flagged in requests < 2.31.0, so hopefully this would resolve that, as well.

## Misc

From a fresh python 3.9.16 venv via direnv:

```bash
export PYENV_VERSION=3.9.16

layout python3
```

Then

```bash
which detect-secrets
detect-secrets not found

pip install --upgrade "git+https://github.com/bigpick/detect-secrets.git@unpin-requests-dep#egg=detect-secrets"

detect-secrets --version
0.13.1+ibm.61.dss

detect-secrets scan --update .secrets.baseline --use-all-plugins .
echo $?
0

detect-secrets audit .secrets.baseline
Nothing to audit!
```
