### PR TITLE
Update artifactory.py

### DIFF
--- a/detect_secrets/plugins/artifactory.py
+++ b/detect_secrets/plugins/artifactory.py
@@ -15,6 +15,8 @@ class ArtifactoryDetector(RegexBasedDetector):
         re.compile(r'(?:(?<==|:|")|(?<=\s)|(?<=^))AKC[a-zA-Z0-9]{10,}'),    # api token
         # artifactory encrypted passwords begin with AP[A-Z]
         re.compile(r'(?:(?<==|:|")|(?<=\s)|(?<=^))AP[\dABCDEF][a-zA-Z0-9]{8,}'),    # password
+        # artifactory identity tokens are different (base64 encoded reftkn:) and 64 chars
+        re.compile(r'(?:(?<==|:|")|(?<=\s)|(?<=^))cmVmdGtu[\da-zA-Z]{56}'),
     ]
 
     artifactory_url = 'na.artifactory.swg-devops.com/artifactory'


### PR DESCRIPTION
support for Artifactory identity tokens. This one doesnt work https://github.com/IBM/detect-secrets/pull/115

All Artifactory identity tokens are 64 characters long and always start with `cmVmdGtu`. I tested it against a few dozen Artifactory identity tokens with success. 