### PR TITLE
feat: add `--no-version-check` cmdline option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 git:
     depth: false
 services:
@@ -17,12 +18,10 @@ deploy:
           repo: IBM/detect-secrets
 matrix:
     include:
-        - env: TOXENV=py37
-          python: 3.7.13
-          dist: xenial # Required for Python >= 3.7 (travis-ci/travis-ci#9069), the GitHub Travis build will use Python 3.7.1 by default if you provide 3.7 without a patch version and the build will fail with AttributeError: 'str' object has no attribute 'name'
         - env: TOXENV=py38
-          python: 3.8
-          dist: xenial # Required for Python >= 3.7 (travis-ci/travis-ci#9069)
+          python: 3.8.18
+        - env: TOXENV=py39
+          python: 3.9.18
 before_install:
     - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
     - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub Enterprise

--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.61.dss'
+VERSION = '0.13.1+ibm.62.dss'

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -42,6 +42,14 @@ def add_no_verify_flag(parser):
     )
 
 
+def add_no_version_check_flag(parser):
+    parser.add_argument(
+        '--no-version-check',
+        action='store_true',
+        help='Disables detect-secrets up-to-date version check.',
+    )
+
+
 def add_output_verified_false_flag(parser):
     parser.add_argument(
         '--output-verified-false',
@@ -75,7 +83,9 @@ class ParserBuilder(object):
         self.add_default_arguments()
 
     def add_default_arguments(self):
-        self._add_verbosity_argument()._add_version_argument()
+        self._add_no_version_check_flag()\
+            ._add_verbosity_argument()\
+            ._add_version_argument()
 
     def add_pre_commit_arguments(self):
         self._add_filenames_argument()\
@@ -158,6 +168,10 @@ class ParserBuilder(object):
 
     def _add_no_verify_flag(self):
         add_no_verify_flag(self.parser)
+        return self
+
+    def _add_no_version_check_flag(self):
+        add_no_version_check_flag(self.parser)
         return self
 
     def _add_output_verified_false_flag(self):

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -18,9 +18,6 @@ def parse_args(argv, parserBuilder):
 
 
 def main(argv=None):
-
-    version_check()
-
     if len(sys.argv) == 1:  # pragma: no cover
         sys.argv.append('-h')
 
@@ -29,6 +26,9 @@ def main(argv=None):
 
     if args.verbose:  # pragma: no cover
         log.set_debug_level(3)
+
+    if not args.no_version_check:
+        version_check()
 
     if args.action == 'scan':
         automaton = None

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -26,10 +26,12 @@ def parse_args(argv):
 
 
 def main(argv=None):
-    version_check()
     args = parse_args(argv)
     if args.verbose:  # pragma: no cover
         log.set_debug_level(3)
+
+    if not args.no_version_check:
+        version_check()
 
     try:
         # If baseline is provided, we first want to make sure

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -7,6 +7,9 @@ import requests
 from packaging.version import parse
 
 from detect_secrets import VERSION
+from detect_secrets.core.log import get_logger
+
+log = get_logger(format_string='%(message)s')
 
 
 def version_check():
@@ -14,6 +17,12 @@ def version_check():
     # get latest version from GHE
     yellow = '\033[93m'
     end_yellow = '\033[0m'
+
+    current_version = parse(VERSION)
+    log.debug(
+        'detect-secrets: checking if up-to-date: version=%s',
+        current_version,
+    )
     try:
         resp = requests.get(
             (
@@ -24,7 +33,10 @@ def version_check():
         )
         resp.raise_for_status()
         latest_version = parse(resp.text)
-        current_version = parse(VERSION)
+        log.debug(
+            'detect-secrets: latest_version=%s up-to-date=%r',
+            latest_version, current_version >= latest_version,
+        )
         if current_version < latest_version:
             print(
                 yellow +

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = detect_secrets
 # These should match the travis env list
-envlist = py{36,37,38,39}
+envlist = py{38,39}
 skip_missing_interpreters = true
 # disabling this option until latest venv-update version is compatible with pip v21
 # tox_pip_extensions_ext_venv_update = true
@@ -17,14 +17,6 @@ commands =
     coverage report --show-missing --include=tests/* --fail-under 100
     coverage report --show-missing --include=detect_secrets/* --fail-under 97
     pre-commit run --all-files --show-diff-on-failure
-
-[testenv:py37]
-commands =
-    coverage erase
-    coverage run -m pytest tests
-    coverage report --show-missing --include=tests/* --fail-under 100
-    coverage report --show-missing --include=detect_secrets/* --fail-under 97
-    # Skip pre-commit hook for py37 since flake8 requires Python >= 3.8.1.
 
 [testenv:venv]
 envdir = venv


### PR DESCRIPTION
Skip the remote version check (to s3) if the user passes `--no-version-check` as a cmdline option.

Fixes IBM/detect-secrets#42