### PR TITLE
Add support for ppc64le for detect-secrets:redhat-ubi image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - echo -e "machine github.com\n  login $GH_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub
     - echo -e "machine github.ibm.com\n  login $GHE_ACCESS_TOKEN" >> ~/.netrc # Login to GitHub Enterprise
 install:
-    - pip install "certifi>=2022.12.07" "setuptools>=65.5.1" tox pipenv
+    - pip install "certifi>=2024.07.04" "setuptools>=65.5.1" tox pipenv
 script: make setup-trivy && make setup-cosign && make trivy-scan-python-vulnerabilities && make test
 cache:
     directories:

--- a/Dockerfiles/detect-secrets/01.detect-secrets-redhat-ubi-ppc64le.Dockerfile
+++ b/Dockerfiles/detect-secrets/01.detect-secrets-redhat-ubi-ppc64le.Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8-minimal as base
+LABEL maintainer="squad:git-defenders" url="https://github.ibm.com/whitewater/whitewater-detect-secrets"
+
+User root
+# install python 3.8 and corresponding pip ... install git (used in DS scan)
+RUN microdnf -y install python38 python38-pip python38-devel git cargo openssl-devel
+RUN microdnf -y update
+
+RUN pip3 install --upgrade pip setuptools wheel
+
+
+FROM base
+
+COPY README.md /code/
+COPY setup.py /code/
+COPY setup.cfg /code/
+COPY detect_secrets /code/detect_secrets
+
+RUN pip3 install /code
+
+WORKDIR /code
+
+ENTRYPOINT [ "detect-secrets" ]
+CMD [ "scan", "/code" ]

--- a/Dockerfiles/detect-secrets/02.detect-secrets-redhat-ubi-custom.Dockerfile
+++ b/Dockerfiles/detect-secrets/02.detect-secrets-redhat-ubi-custom.Dockerfile
@@ -1,4 +1,4 @@
-FROM git-defenders/detect-secrets:redhat-ubi
+FROM git-defenders/detect-secrets:redhat-ubi-amd64
 
 COPY scripts/run-in-pipeline.sh /
 

--- a/Makefile.ibm
+++ b/Makefile.ibm
@@ -76,15 +76,24 @@ docker-test-images:
 	docker run -it $(DOCKER_DOMAIN_LOCAL)/detect-secrets-hook --version
 
 docker-build-images:
-	for dockerfile in Dockerfiles/*/*.Dockerfile; do                                            \
-		image_name=$$(echo -e $$(basename $${dockerfile}) | cut -d\. -f2);                      \
-		if [ "$${image_name}" == "detect-secrets-redhat-ubi" ]; then							\
-			image_name="detect-secrets:redhat-ubi";     								        \
-		elif [ "$${image_name}" == "detect-secrets-redhat-ubi-custom" ]; then				    \
-			image_name="detect-secrets:redhat-ubi-custom"; 										\
-		fi ;																					\
-		docker build -f "$${dockerfile}" -t $(DOCKER_DOMAIN_LOCAL)/$${image_name} .;  			\
-	done
+	for dockerfile in Dockerfiles/*/*.Dockerfile; do               																				\
+		image_name=$$(echo -e $$(basename $${dockerfile}) | cut -d\. -f2);																		\
+		case $${image_name} in    																												\
+			"detect-secrets-redhat-ubi")																										\
+				image_name="detect-secrets:redhat-ubi-amd64"; 																					\
+			;;  																																\
+			"detect-secrets-redhat-ubi-ppc64le")																								\
+				image_name="detect-secrets:redhat-ubi-ppc64le";     																			\
+				docker buildx create --use;																										\
+				docker buildx build --load --platform=linux/ppc64le -f "$${dockerfile}" -t $(DOCKER_DOMAIN_LOCAL)/$${image_name} .;  			\
+				continue																														\
+			;;														        																	\
+			"detect-secrets-redhat-ubi-custom")			  																						\
+				image_name="detect-secrets:redhat-ubi-custom";																					\
+			;;																																	\
+		esac;																																	\
+		docker build -f "$${dockerfile}" -t $(DOCKER_DOMAIN_LOCAL)/$${image_name} .;  															\
+	done;																																		\
 
 docker-login:
 	# @echo $(DOCKER_PASS_ART) | docker login -u $(DOCKER_USER_ART) --password-stdin $(DOCKER_REGISTRY_ART);
@@ -93,7 +102,8 @@ docker-login:
 docker-publish-images: docker-login
 	# Tagged UBI images in special way (since they are pre-tagged); these will be the frozen versions for UBI images
 	if [ -n "$(TRAVIS_TAG)" ]; then \
-		docker tag $(DOCKER_DOMAIN_LOCAL)/detect-secrets:redhat-ubi $(DOCKER_DOMAIN_LOCAL)/detect-secrets:$(subst +,.,$(TRAVIS_TAG))-redhat-ubi ;  \
+		docker tag $(DOCKER_DOMAIN_LOCAL)/detect-secrets:redhat-ubi-amd64 $(DOCKER_DOMAIN_LOCAL)/detect-secrets:$(subst +,.,$(TRAVIS_TAG))-redhat-ubi-amd64 ;  \
+		docker tag $(DOCKER_DOMAIN_LOCAL)/detect-secrets:redhat-ubi-ppc64le $(DOCKER_DOMAIN_LOCAL)/detect-secrets:$(subst +,.,$(TRAVIS_TAG))-redhat-ubi-ppc64le ;  \
 		docker tag $(DOCKER_DOMAIN_LOCAL)/detect-secrets:redhat-ubi-custom $(DOCKER_DOMAIN_LOCAL)/detect-secrets:$(subst +,.,$(TRAVIS_TAG))-redhat-ubi-custom ;  \
 	fi
 
@@ -107,10 +117,31 @@ docker-publish-images: docker-login
 	# Publish images to the different Registries; publish list is built within deploy target
 	for image_name in $(DOCKER_IMAGES_TO_PUBLISH) ; do  \
 		for registry in $(DOCKER_REGISTRIES) ; do   \
+			if [ $image_name == "detect-secrets:redhat-ubi" ] || [ $image_name == "detect-secrets:$(subst +,.,$(TRAVIS_TAG))-redhat-ubi" ]; then \
+				$(MAKE) docker-publish-manifest	\
+				IMAGE_NAME=$${image_name} DOCKER_REGISTRY=$${registry}; \
+				continue	\
+			fi	\
 			$(MAKE) docker-publish-image    \
 			IMAGE_NAME=$${image_name} DOCKER_REGISTRY=$${registry}; \
 		done   \
 	done
+
+docker-publish-manifest:
+	OG_IMAGE_NAME=${IMAGE_NAME};	\
+	$(MAKE) docker-publish-image IMAGE_NAME=${IMAGE_NAME}-amd64; \
+	$(MAKE) docker-publish-image IMAGE_NAME=${IMAGE_NAME}-ppc64le; \
+
+	export DOCKER_CLI_EXPERIMENTAL=enabled;	\
+	docker manifest create $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME) $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME)-amd64 $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME)-ppc64le; \
+	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME); \
+
+
+	@echo "Signing image $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME)"; \
+	$(COSIGN) sign --key env://COSIGN_PRIVATE_KEY --yes $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME); \
+
+	@echo "Verifying image $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME)"; \
+	$(COSIGN) verify --key env://COSIGN_PUBLIC_KEY "$(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(OG_IMAGE_NAME)";
 
 docker-publish-image:
 	docker tag $(DOCKER_DOMAIN_LOCAL)/$(IMAGE_NAME) $(DOCKER_REGISTRY)/$(DOCKER_DOMAIN)/$(IMAGE_NAME); \


### PR DESCRIPTION
This PR trying to create a multi arch manifest for detect-secrets:redhat-ubi image with amd64 and ppc64le images.

I can see there is an existing [issue](https://github.ibm.com/Whitewater/whitewater-detect-secrets/issues/558) which requests for ppc64le supported detect-secrets:redhat-ubi image image. 
I am part of power software team. We also have a requirement for this image to support ppc64le arch for our CP4D on power use case.

Could you please help me with this?