### PR TITLE
fix: fix variable format in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [wheel]
 universal = True


### PR DESCRIPTION
It looks like setuptools has deprecated dash-separated keys as of [v78 release](https://setuptools.pypa.io/en/stable/history.html#v78-0-0). This PR updates setup.cfg to lower_snake_case.