### PR TITLE
scan files with spaces in their name

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -371,7 +371,7 @@ def _get_git_tracked_files(rootdir='.'):
                 ],
                 stderr=fnull,
             )
-        for filename in git_files.decode('utf-8').split():
+        for filename in git_files.decode('utf-8').split('\n'):
             relative_path = util.get_relative_path_if_in_cwd(rootdir, filename)
             if relative_path:
                 output.append(relative_path)

--- a/test_data/files/file with secrets.py
+++ b/test_data/files/file with secrets.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+# Will change this later.
+SUPER_SECRET_VALUES = '60b725f10c9c85c70d97880dfe8191b3', '3b5d5c3712955042212316173ccf37be'
+
+
+def main():
+    print('Hello world!')
+
+
+if __name__ == '__main__':
+    main()

--- a/test_data/files/tmp/file with secrets.py
+++ b/test_data/files/tmp/file with secrets.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+# Will change this later.
+SUPER_SEECRET_VALUE = 'c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5'
+VERY_SECRET_TOO = 'f6CGV4aMM9zedoh3OUNbSakBymo7yplB'  # pragma: allowlist secret
+
+
+def main():
+    print('Hello world!')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -55,9 +55,11 @@ class TestInitializeBaseline:
     def test_basic_usage(self, path):
         results = self.get_results(path=path)
 
-        assert len(results.keys()) == 2
+        assert len(results.keys()) == 4
         assert len(results['test_data/files/file_with_secrets.py']) == 1
         assert len(results['test_data/files/tmp/file_with_secrets.py']) == 2
+        assert len(results['test_data/files/file with secrets.py']) == 2
+        assert len(results['test_data/files/tmp/file with secrets.py']) == 1
 
     @pytest.mark.parametrize(
         'path',
@@ -92,8 +94,8 @@ class TestInitializeBaseline:
 
         assert len(results['test_data/files/file_with_secrets.py']) == 1
         assert len(results['test_data/files/tmp/file_with_secrets.py']) == 2
-        assert 'test_data/files/file_with_secrets.py' in results
-        assert 'test_data/files/tmp/file_with_secrets.py' in results
+        assert 'test_data/files/file with secrets.py' not in results
+        assert 'test_data/files/tmp/file with secrets.py' not in results
 
     def test_with_multiple_non_existent_files(self):
         with mock.patch(
@@ -123,20 +125,25 @@ class TestInitializeBaseline:
         assert 'test_data/files/file_with_secrets.py' in results
         assert 'test_data/files/tmp/file_with_secrets.py' in results
         assert 'test_data/files/file_with_no_secrets.py' not in results
+        assert 'test_data/files/file with secrets.py' in results
+        assert 'test_data/files/tmp/file with secrets.py' in results
         assert 'non-existent-file.B' not in results
 
     def test_exclude_regex(self):
         results = self.get_results(exclude_files_regex='tmp*')
 
-        assert len(results.keys()) == 1
+        assert len(results.keys()) == 2
         assert 'test_data/files/file_with_secrets.py' in results
+        assert 'test_data/files/file with secrets.py' in results
 
     def test_exclude_regex_at_root_level(self):
         results = self.get_results(exclude_files_regex='file_with_secrets.py')
 
         # All files_with_secrets.py should be ignored, both at the root
         # level, and the nested file in tmp.
-        assert not results
+        assert len(results.keys()) == 2
+        assert 'test_data/files/file with secrets.py' in results
+        assert 'test_data/files/tmp/file with secrets.py' in results
 
     def test_no_files_in_git_repo(self):
         with mock_git_calls(
@@ -170,7 +177,7 @@ class TestInitializeBaseline:
             path=['test_data/files'],
             scan_all_files=True,
         )
-        assert len(results.keys()) == 2
+        assert len(results.keys()) == 4
 
     def test_scan_all_files_with_bad_symlinks(self):
         with mock.patch(


### PR DESCRIPTION
The `scan` command did not scan the file whose name contains ' ' (space), like `file with secrets.py
`.

Added test files that have space-included name.