### PR TITLE
Add pyproject.toml for PEP 517 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #169 

This file defines the PEP 517 build system for detect-secrets using setuptools.

Adding pyproject.toml allows pip to build detect-secrets via the standardized PEP 517 interface instead of the legacy setup.py build. This avoids the deprecation warning shown during installation with pip 25.