### PR TITLE
Add pyproject.toml for PEP 517 build

### DIFF
--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.62.dss'
+VERSION = '0.13.1+ibm.63.dss'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,20 @@ if sys.version_info.major == 2:
 from setuptools import find_packages
 from setuptools import setup
 
-from detect_secrets import VERSION
+import re
+from pathlib import Path
+
+def get_version():
+    init_path = Path(__file__).parent / "detect_secrets" / "__init__.py"
+    content = init_path.read_text()
+    match = re.search(r"^VERSION\s*=\s*['\"]([^'\"]+)['\"]", content, re.MULTILINE)
+    return match.group(1)
 
 
 setup(
     name='detect_secrets',
     packages=find_packages(exclude=(['test*', 'tmp*'])),
-    version=VERSION,
+    version=get_version(),
     description='Tool for detecting secrets in the codebase',
     long_description=(
         'Check out detect-secrets on `GitHub ' +


### PR DESCRIPTION
Fixes #169 

This file defines the PEP 517 build system for detect-secrets using setuptools.

NOTE: Pip uses the isolated build environment, as mandated by PEP 517, s importing anything from your package in setup.py now fails.

Adding pyproject.toml allows pip to build detect-secrets via the standardized PEP 517 interface instead of the legacy setup.py build. This avoids the deprecation warning shown during installation with pip 25.

<img width="1476" height="745" alt="image" src="https://github.com/user-attachments/assets/cd271338-b27a-4165-bc24-25ad313ee0f9" />
