### PR TITLE
--diff-branch option to allow for scans of changed files only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # You are encouraged to use static refs such as tags, instead of branch name
       #
       # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-      rev: 0.13.1+ibm.63.dss
+      rev: 0.13.1+ibm.64.dss
       hooks:
           - id: detect-secrets # pragma: whitelist secret
             # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-02T20:03:24Z",
+  "generated_at": "2025-11-24T17:44:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -200,7 +200,7 @@
         "hashed_secret": "f32a07369c6fd4eaacb1f5a8877824ef98204a1c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 102,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -208,7 +208,7 @@
         "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 108,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -242,7 +242,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.63.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -205,7 +205,8 @@ class ScanOptions:
         self._add_initialize_baseline_argument()\
             ._add_adhoc_scanning_argument()\
             ._add_output_raw_argument()\
-            ._add_suppress_unscannable_file_warnings()
+            ._add_suppress_unscannable_file_warnings()\
+            ._add_diff_branch()\
 
         PluginOptions(self.parser).add_arguments()
 
@@ -287,6 +288,18 @@ class ScanOptions:
 
     def _add_suppress_unscannable_file_warnings(self):
         add_suppress_unscannable_file_warnings(self.parser)
+        return self
+
+    def _add_diff_branch(self):
+        self.parser.add_argument(
+            '--diff-branch',
+            type=str,
+            help=(
+                'Scan only files that are tracked to git containing '
+                'differences from the named branch.'
+            ),
+            dest='diff_branch',
+        )
         return self
 
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -189,6 +189,7 @@ def _perform_scan(args, plugins, automaton, word_list_hash):
         output_raw=args.output_raw,
         output_verified_false=args.output_verified_false,
         suppress_unscannable_file_warnings=args.suppress_unscannable_file_warnings,
+        diff_branch=args.diff_branch,
     ).format_for_baseline_output()
 
     if old_baseline:
@@ -206,7 +207,8 @@ def _get_existing_baseline(import_filename):
         try:
             return _read_from_file(import_filename[0])
         except FileNotFoundError as fnf_error:
-            if fnf_error.errno == 2:  # create new baseline if not existed
+            if fnf_error.errno == 2 or fnf_error.errno == 129:
+                # create new baseline if not existed, 129 is for z/OS
                 return None
             else:  # throw exception for other cases
                 print(

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -76,6 +76,9 @@ detect-secrets scan file1 file2
 
 # Scan all files except for .gitignore
 detect-secrets scan --all-files
+
+# Scan only files that are tracked to git containing differences from the named branch
+detect-secrets scan --diff-branch diff_branch_name
 ```
 
 ### Ad-hoc scan on a single string

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -96,6 +96,7 @@ class TestMain:
             word_list_file=None,
             word_list_hash=None,
             suppress_unscannable_file_warnings=False,
+            diff_branch=None,
         )
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
@@ -113,6 +114,7 @@ class TestMain:
             word_list_file=None,
             word_list_hash=None,
             suppress_unscannable_file_warnings=False,
+            diff_branch=None,
         )
 
     def test_scan_with_exclude_args(self, mock_baseline_initialize):
@@ -132,6 +134,7 @@ class TestMain:
             word_list_file=None,
             word_list_hash=None,
             suppress_unscannable_file_warnings=False,
+            diff_branch=None,
         )
 
     @pytest.mark.parametrize(
@@ -217,6 +220,25 @@ class TestMain:
             word_list_file=None,
             word_list_hash=None,
             suppress_unscannable_file_warnings=False,
+            diff_branch=None,
+        )
+
+    def test_scan_with_diff_branch(self, mock_baseline_initialize):
+        with mock_stdin():
+            assert main('scan --diff-branch some_branch_here'.split()) == 0
+
+        mock_baseline_initialize.assert_called_once_with(
+            plugins=Any(tuple),
+            exclude_files_regex=None,
+            exclude_lines_regex=None,
+            path='.',
+            should_scan_all_files=False,
+            output_raw=False,
+            output_verified_false=False,
+            word_list_file=None,
+            word_list_hash=None,
+            suppress_unscannable_file_warnings=False,
+            diff_branch='some_branch_here',
         )
 
     def test_reads_from_stdin(self, mock_merge_baseline):
@@ -274,6 +296,7 @@ class TestMain:
             word_list_file=None,
             word_list_hash=None,
             suppress_unscannable_file_warnings=False,
+            diff_branch=None,
         )
         mock_merge_baseline.assert_not_called()
 


### PR DESCRIPTION
My git component has an extremely large code base and it takes hours to
scan all files in the repository. Our builds only perform incremental
changes, building only the changed source files. Because of this it is
only necessary to scan changed source files during the build process.

This enhancement saves hours of downtime on incremental builds only
changing a few source files out of thousands.

There is also a tweak to allow detect-secrets to run on z/OS by
acknowledging code 129 as a file not found code.