### PR TITLE
pinning chardet to resolve new binary file detection bug

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ boxsdk[jwt]<4.0.0
 pyahocorasick
 tabulate
 binaryornot
+chardet>=3.0.2,<7.0.0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'packaging',
         'tabulate',
         'binaryornot',
+        'chardet>=3.0.2,<7.0.0',
     ],
     extras_require={
         'word_list': [


### PR DESCRIPTION
Excluding the enhanced exception handling logic from Bryan, in order to keep regression risk to a minimum, given available time. I have tested this update & essentially it preserves the status quo ante (we were using chardet 6 prior to the release of chardet 7). 