### PR TITLE
feat(ip_public): Add IPPublicDetector plugin

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -618,6 +618,12 @@ class PluginOptions:
             help_text='Disables scans for GitHub credentials',
             filename='github_token',
         ),
+        PluginDescriptor(
+            classname='IPPublicDetector',
+            flag_text='--no-ip-public-scan',
+            help_text='Disables scans for public IPv4 addresses',
+            filename='ip_public',
+        ),
     ]
     opt_in_plugins = [
         PluginDescriptor(

--- a/detect_secrets/plugins/ip_public.py
+++ b/detect_secrets/plugins/ip_public.py
@@ -1,0 +1,47 @@
+import re
+
+from .base import RegexBasedDetector
+
+
+class IPPublicDetector(RegexBasedDetector):
+    """Scans for public ip address (ipv4)
+
+    Some non-public ipv4 addresses are ignored, such as:
+        - 127.
+        - 10.
+        - 172.(16-31)
+        - 192.168.
+        - 169.254. - Link Local Address IPv4
+
+    Reference:
+    https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml
+    https://en.wikipedia.org/wiki/Private_network
+    """
+    secret_type = 'Public IP (ipv4)'
+
+    denylist_ipv4_address = r"""
+        (?<![\w.])         # Negative lookbehind: Ensures no preceding word character or dot
+        (                  # Start of the main capturing group
+            (?!            # Negative lookahead: Ensures the following pattern doesn't match
+                192\.168\. # Exclude "192.168."
+                |127\.     # Exclude "127."
+                |10\.      # Exclude "10."
+                |169\.254\. # Exclude IPv4 Link Local Address (169.254.0.0/16)
+                |172\.(?:1[6-9]|2[0-9]|3[01])   # Exclude "172." with specific ranges
+            )
+            (?:            # Non-capturing group for octets
+                           # Match numbers 0-255 followed by dot, properly handle leading zeros
+                (?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.
+            ){3}           # Repeat for three octets
+                           # Match final octet (0-255), properly handle leading zeros
+            (?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])
+            (?:            # Optional non-capturing group for port number
+                :\d{1,5}   # Match colon followed by 1 to 5 digits
+            )?
+        )                  # End of the main capturing group
+        (?![\w.])          # Negative lookahead: Ensures no following word character or dot
+    """
+
+    denylist = [
+        re.compile(denylist_ipv4_address, flags=re.IGNORECASE | re.VERBOSE),
+    ]

--- a/detect_secrets/plugins/ip_public.py
+++ b/detect_secrets/plugins/ip_public.py
@@ -27,7 +27,7 @@ class IPPublicDetector(RegexBasedDetector):
                 |127\.     # Exclude "127."
                 |10\.      # Exclude "10."
                 |169\.254\. # Exclude IPv4 Link Local Address (169.254.0.0/16)
-                |172\.(?:1[6-9]|2[0-9]|3[01])   # Exclude "172." with specific ranges
+                |172\.(?:1[6-9]|2[0-9]|3[01])\.   # Exclude "172.16-31." with specific ranges
             )
             (?:            # Non-capturing group for octets
                            # Match numbers 0-255 followed by dot, properly handle leading zeros

--- a/tests/plugins/ip_public_test.py
+++ b/tests/plugins/ip_public_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+from detect_secrets.plugins.ip_public import IPPublicDetector
+
+
+class TestIPPublicDetector:
+
+    class TestIPv4:
+        """
+        Testing strategy
+
+        Cover the cartesian product of these partitions:
+
+          1. Partition on ip address format:
+              a. Valid ipv4 address
+
+          2. Partition on ip address type:
+              a. Public
+              b. Non-public
+
+        And cover this case:
+          1. Partition on ip address format:
+              a. Invalid ipv4 address
+        """
+
+        @pytest.mark.parametrize(
+            'payload, should_flag',
+            [
+                # Valid IPv4 addresses, Public
+                ('133.133.133.133', True),
+                ('This line has an IP address 133.133.133.133@something else', True),
+                ('133.133.133.133:8080', True),
+                ('This line has an IP address: 133.133.133.133:8080@something else', True),
+                ('1.1.1.1', True),
+                # Valid IPv4 addresses, Non-public
+                ('127.0.0.1', False),
+                ('10.0.0.1', False),
+                ('172.16.0.1', False),
+                ('192.168.0.1', False),
+                ('169.254.169.254', False),
+                # Invalid IPv4 addresses
+                ('256.256.256.256', False),
+                ('1.2.3', False),
+                ('1.2.3.4.5.6', False),
+                ('1.2.3.4.5.6.7.8', False),
+                ('1.2.3.04', False),
+                ('noreply@github.com', False),
+                ('github.com', False),
+            ],
+        )
+        def test_analyze_line(self, payload, should_flag):
+            logic = IPPublicDetector()
+
+            output = logic.analyze_line(filename='mock_filename', line=payload)
+            assert len(output) == int(should_flag)

--- a/tests/plugins/ip_public_test.py
+++ b/tests/plugins/ip_public_test.py
@@ -38,6 +38,10 @@ class TestIPPublicDetector:
                 ('172.16.0.1', False),
                 ('192.168.0.1', False),
                 ('169.254.169.254', False),
+                # 172.x boundary: 172.15 and 172.32 are public, 172.16-31 are private
+                ('172.15.0.1', True),
+                ('172.32.0.1', True),
+                ('172.160.0.1', True),
                 # Invalid IPv4 addresses
                 ('256.256.256.256', False),
                 ('1.2.3', False),
@@ -51,5 +55,5 @@ class TestIPPublicDetector:
         def test_analyze_line(self, payload, should_flag):
             logic = IPPublicDetector()
 
-            output = logic.analyze_line(filename='mock_filename', line=payload)
+            output = logic.analyze_line(payload, 1, 'mock_filename')
             assert len(output) == int(should_flag)


### PR DESCRIPTION
### Description

Port the `IPPublicDetector` from [Yelp/detect-secrets](https://github.com/yelp/detect-secrets) upstream. Detects public IPv4 addresses while excluding private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), loopback (127.0.0.0/8), and link-local (169.254.0.0/16) addresses.