### PR TITLE
feat(telegram_token): Add TelegramBotTokenDetector plugin

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -618,6 +618,12 @@ class PluginOptions:
             help_text='Disables scans for GitHub credentials',
             filename='github_token',
         ),
+        PluginDescriptor(
+            classname='TelegramBotTokenDetector',
+            flag_text='--no-telegram-bot-token-scan',
+            help_text='Disables scans for Telegram bot tokens',
+            filename='telegram_token',
+        ),
     ]
     opt_in_plugins = [
         PluginDescriptor(

--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -19,13 +19,19 @@ class TelegramBotTokenDetector(RegexBasedDetector):
     ]
 
     def verify(self, token, *args, **kwargs):  # pragma: no cover
-        response = requests.get(
-            'https://api.telegram.org/bot{}/getMe'.format(
-                token,
-            ),
-        )
-        return (
-            VerifiedResult.VERIFIED_TRUE
-            if response.status_code == 200
-            else VerifiedResult.VERIFIED_FALSE
-        )
+        try:
+            response = requests.get(
+                'https://api.telegram.org/bot{}/getMe'.format(
+                    token,
+                ),
+                timeout=5,
+            )
+        except requests.exceptions.RequestException:
+            return VerifiedResult.UNVERIFIED
+
+        if response.status_code == 200:
+            return VerifiedResult.VERIFIED_TRUE
+
+        # For unexpected status codes (e.g., 429/5xx), avoid
+        # incorrectly marking the token as invalid.
+        return VerifiedResult.UNVERIFIED

--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -1,0 +1,31 @@
+"""
+This plugin searches for Telegram bot tokens
+"""
+import re
+
+import requests
+
+from ..constants import VerifiedResult
+from .base import RegexBasedDetector
+
+
+class TelegramBotTokenDetector(RegexBasedDetector):
+    """Scans for Telegram bot tokens."""
+    secret_type = 'Telegram Bot Token'
+
+    denylist = [
+        # refs https://core.telegram.org/bots/api#authorizing-your-bot
+        re.compile(r'^\d{8,10}:[0-9A-Za-z_-]{35}$'),
+    ]
+
+    def verify(self, secret: str) -> VerifiedResult:  # pragma: no cover
+        response = requests.get(
+            'https://api.telegram.org/bot{}/getMe'.format(
+                secret,
+            ),
+        )
+        return (
+            VerifiedResult.VERIFIED_TRUE
+            if response.status_code == 200
+            else VerifiedResult.VERIFIED_FALSE
+        )

--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -5,7 +5,7 @@ import re
 
 import requests
 
-from ..constants import VerifiedResult
+from detect_secrets.core.constants import VerifiedResult
 from .base import RegexBasedDetector
 
 
@@ -18,10 +18,10 @@ class TelegramBotTokenDetector(RegexBasedDetector):
         re.compile(r'^\d{8,10}:[0-9A-Za-z_-]{35}$'),
     ]
 
-    def verify(self, secret: str) -> VerifiedResult:  # pragma: no cover
+    def verify(self, token, *args, **kwargs):  # pragma: no cover
         response = requests.get(
             'https://api.telegram.org/bot{}/getMe'.format(
-                secret,
+                token,
             ),
         )
         return (

--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -15,7 +15,7 @@ class TelegramBotTokenDetector(RegexBasedDetector):
 
     denylist = [
         # refs https://core.telegram.org/bots/api#authorizing-your-bot
-        re.compile(r'^\d{8,10}:[0-9A-Za-z_-]{35}$'),
+        re.compile(r'(?<![:\w])\d{8,10}:[0-9A-Za-z_-]{35}(?![0-9A-Za-z_-])'),
     ]
 
     def verify(self, token, *args, **kwargs):  # pragma: no cover
@@ -31,7 +31,7 @@ class TelegramBotTokenDetector(RegexBasedDetector):
 
         if response.status_code == 200:
             return VerifiedResult.VERIFIED_TRUE
+        if response.status_code == 401:
+            return VerifiedResult.VERIFIED_FALSE
 
-        # For unexpected status codes (e.g., 429/5xx), avoid
-        # incorrectly marking the token as invalid.
         return VerifiedResult.UNVERIFIED

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from detect_secrets.plugins.telegram_token import TelegramBotTokenDetector
+
+
+class TestTelegramTokenDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', False),
+            ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
+            ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),
+            ('foo', False),
+            ('arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssddddddddddddd', False),
+        ],
+    )
+    def test_analyze(self, payload, should_flag):
+        logic = TelegramBotTokenDetector()
+        output = logic.analyze_line(filename='mock_filename', line=payload)
+
+        assert len(output) == int(should_flag)

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -8,9 +8,14 @@ class TestTelegramTokenDetector:
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
-            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', False),
             ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
             ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
+            # Embedded in assignments, quotes, JSON
+            ('TELEGRAM_TOKEN=110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('token = "110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw"', True),
+            ('{"bot_token": "110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw"}', True),
+            # Should not match
+            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', False),
             ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),
             ('foo', False),
             ('arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssddddddddddddd', False),

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -18,6 +18,6 @@ class TestTelegramTokenDetector:
     )
     def test_analyze(self, payload, should_flag):
         logic = TelegramBotTokenDetector()
-        output = logic.analyze_line(filename='mock_filename', line=payload)
+        output = logic.analyze_line(payload, 1, 'mock_filename')
 
         assert len(output) == int(should_flag)


### PR DESCRIPTION
### Description

Port the `TelegramBotTokenDetector` from [Yelp/detect-secrets](https://github.com/yelp/detect-secrets) upstream. Includes anchored regex `(^...$)` to prevent false positives from substrings like AWS ARNs matching the bot token pattern.