### PR TITLE
support boxsdk > v4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # You are encouraged to use static refs such as tags, instead of branch name
       #
       # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-      rev: 0.13.1+ibm.63.dss
+      rev: 0.13.1+ibm.64.dss
       hooks:
           - id: detect-secrets # pragma: whitelist secret
             # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "test_data/.*|tests/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-02T20:03:24Z",
+  "generated_at": "2026-03-27T23:43:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.63.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.13.1+ibm.64.dss'
+VERSION = '0.13.1+ibm.65.dss'

--- a/detect_secrets/plugins/box.py
+++ b/detect_secrets/plugins/box.py
@@ -1,5 +1,14 @@
-from boxsdk import Client
-from boxsdk import JWTAuth
+try:
+    from boxsdk import Client
+    from boxsdk import JWTAuth
+
+    BOX_SDK_FLAVOR = 'legacy'
+except ImportError:
+    from box_sdk_gen import BoxClient as Client
+    from box_sdk_gen import BoxJWTAuth as JWTAuth
+    from box_sdk_gen import JWTConfig
+
+    BOX_SDK_FLAVOR = 'generated'
 
 from .base import RegexBasedDetector
 from detect_secrets.core.constants import VerifiedResult
@@ -106,17 +115,31 @@ def get_box_user(
     clientid, token, enterpriseid,
     publickeyid, passphrase, privatekey,
 ):
-    auth = JWTAuth(
-        client_id=clientid,
-        client_secret=token,
-        enterprise_id=enterpriseid,
-        jwt_key_id=publickeyid,
-        rsa_private_key_passphrase=passphrase.encode(),
-        rsa_private_key_data=privatekey,
-    )
     try:
+        if BOX_SDK_FLAVOR == 'legacy':
+            auth = JWTAuth(
+                client_id=clientid,
+                client_secret=token,
+                enterprise_id=enterpriseid,
+                jwt_key_id=publickeyid,
+                rsa_private_key_passphrase=passphrase.encode(),
+                rsa_private_key_data=privatekey,
+            )
+            client = Client(auth)
+
+            return client.user().get().name
+
+        auth = JWTAuth(config=JWTConfig(
+            client_id=clientid,
+            client_secret=token,
+            enterprise_id=enterpriseid,
+            jwt_key_id=publickeyid,
+            private_key_passphrase=passphrase,
+            private_key=privatekey,
+        ))
         client = Client(auth)
-        return client.user().get().name
+
+        return client.users.get_user_me().name
     except Exception:
         return None
 

--- a/detect_secrets/plugins/box.py
+++ b/detect_secrets/plugins/box.py
@@ -129,14 +129,16 @@ def get_box_user(
 
             return client.user().get().name
 
-        auth = JWTAuth(config=JWTConfig(
-            client_id=clientid,
-            client_secret=token,
-            enterprise_id=enterpriseid,
-            jwt_key_id=publickeyid,
-            private_key_passphrase=passphrase,
-            private_key=privatekey,
-        ))
+        auth = JWTAuth(
+            config=JWTConfig(
+                client_id=clientid,
+                client_secret=token,
+                enterprise_id=enterpriseid,
+                jwt_key_id=publickeyid,
+                private_key_passphrase=passphrase,
+                private_key=privatekey,
+            ),
+        )
         client = Client(auth)
 
         return client.users.get_user_me().name

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ tox-pip-extensions
 tox>=3.8
 unidiff
 ibm_db
-boxsdk[jwt]<4.0.0
+boxsdk[jwt]
 pyahocorasick
 tabulate
 binaryornot

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'pyyaml',
         'requests',
         'urllib3>2.4.0',
-        'boxsdk[jwt]<4.0.0',
+        'boxsdk[jwt]',
         'packaging',
         'tabulate',
         'binaryornot',

--- a/tests/plugins/box_test.py
+++ b/tests/plugins/box_test.py
@@ -4,6 +4,7 @@ from mock import patch
 from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.box import BoxDetector
+from detect_secrets.plugins.box import BOX_SDK_FLAVOR
 from detect_secrets.plugins.box import find_other_factor
 from detect_secrets.plugins.box import get_box_user
 
@@ -38,11 +39,26 @@ class TestBoxDetector(object):
     @patch('detect_secrets.plugins.box.Client')
     def test_get_box_user(self, mock_box, mock_jwt):
         mock_box.return_value.user.return_value.get.return_value.name = 'Testy'
+        mock_box.return_value.users.get_user_me.return_value.name = 'Testy'
 
         assert get_box_user(
             BOX_CLIENT_ID, BOX_CLIENT_SECRET, BOX_ENTERPRISE_ID,
             BOX_PUBLIC_KEY_ID, BOX_PASSPHRASE, BOX_PRIVATE_KEY,
         ) == 'Testy'
+
+    @patch('detect_secrets.plugins.box.JWTAuth')
+    def test_get_box_user_auth_format(self, mock_jwt):
+        with patch('detect_secrets.plugins.box.Client'):
+            get_box_user(
+                BOX_CLIENT_ID, BOX_CLIENT_SECRET, BOX_ENTERPRISE_ID,
+                BOX_PUBLIC_KEY_ID, BOX_PASSPHRASE, BOX_PRIVATE_KEY,
+            )
+
+        kwargs = mock_jwt.call_args.kwargs
+        if BOX_SDK_FLAVOR == 'legacy':
+            assert kwargs['rsa_private_key_passphrase'] == BOX_PASSPHRASE.encode()
+        else:
+            assert 'config' in kwargs
 
     @patch('detect_secrets.plugins.box.JWTAuth')
     @patch('detect_secrets.plugins.box.Client')
@@ -58,6 +74,7 @@ class TestBoxDetector(object):
     @patch('detect_secrets.plugins.box.Client')
     def test_verify(self, mock_box, mock_jwt):
         mock_box.return_value.user.return_value.get.return_value.name = 'Testy'
+        mock_box.return_value.users.get_user_me.return_value.name = 'Testy'
 
         potential_secret = PotentialSecret('test box', 'test filename', BOX_CLIENT_SECRET)
 

--- a/tests/plugins/box_test.py
+++ b/tests/plugins/box_test.py
@@ -3,8 +3,8 @@ from mock import patch
 
 from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.core.potential_secret import PotentialSecret
-from detect_secrets.plugins.box import BoxDetector
 from detect_secrets.plugins.box import BOX_SDK_FLAVOR
+from detect_secrets.plugins.box import BoxDetector
 from detect_secrets.plugins.box import find_other_factor
 from detect_secrets.plugins.box import get_box_user
 

--- a/user-config/.pre-commit-config.yaml
+++ b/user-config/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     # You are encouraged to use static refs such as tags, instead of branch name
     #
     # Running "pre-commit autoupdate" automatically updates rev to latest tag
-    rev: 0.13.1+ibm.64.dss
+    rev: 0.13.1+ibm.65.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.


### PR DESCRIPTION
Closes #160 #173 

### Motivation
- Add compatibility for a newer/generated Box SDK while preserving support for the legacy `boxsdk` API.
- Remove the strict `<4.0.0` upper bound on the `boxsdk[jwt]` dependency to allow newer releases.
- Bump package/version references used by pre-commit configs to the new internal release.

### Testing
- Ran the plugin unit tests `pytest tests/plugins/box_test.py` 

```bash
❯ source .venv/bin/activate && PYTHONPATH=`pwd` pytest tests/plugins/box_test.py -v

============================= test session starts =============================
collected 21 items                                                            

tests/plugins/box_test.py::TestBoxDetector::test_analyze_line["clientSecret": "12345678abcdefgh12345678ABCDEFGH"-True] PASSED [  4%]
tests/plugins/box_test.py::TestBoxDetector::test_analyze_line[client_secret = 12345678abcdefgh12345678ABCDEFGH-True] PASSED [  9%]
tests/plugins/box_test.py::TestBoxDetector::test_analyze_line[CLIENT-SECRET=12345678abcdefgh12345678ABCDEFGH-True] PASSED [ 14%]
tests/plugins/box_test.py::TestBoxDetector::test_analyze_line["clientsecret":="12345678abcdefgh12345678ABCDEFGH"-True] PASSED [ 19%]
tests/plugins/box_test.py::TestBoxDetector::test_analyze_line["clientSecret": "12345678abcdefgh12345678ABCDEFG2many"-True] PASSED [ 23%]
tests/plugins/box_test.py::TestBoxDetector::test_analyze_line["clientSecret": "12345678abcdnotenough"-False] PASSED [ 28%]
tests/plugins/box_test.py::TestBoxDetector::test_get_box_user PASSED    [ 33%]
tests/plugins/box_test.py::TestBoxDetector::test_get_box_user_auth_format PASSED [ 38%]
tests/plugins/box_test.py::TestBoxDetector::test_get_box_user_invalid_creds PASSED [ 42%]
tests/plugins/box_test.py::TestBoxDetector::test_verify PASSED          [ 47%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_invalid PASSED  [ 52%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_unverified_missing_clientid PASSED [ 57%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_unverified_missing_publickeyid PASSED [ 61%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_unverified_missing_passphrase PASSED [ 66%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_unverified_missing_privatekey PASSED [ 71%]
tests/plugins/box_test.py::TestBoxDetector::test_verify_unverified_missing_enterpriseid PASSED [ 76%]
tests/plugins/box_test.py::TestBoxDetector::test_find_other_factor["clientID": "abcd1234abcd1234abcd1234abcd1234"-(?:client)-(?:id)-([a-z0-9]{32})-expected_result0] PASSED [ 80%]
tests/plugins/box_test.py::TestBoxDetector::test_find_other_factor["publicKeyID": "abcd1234"-(?:public(?:-|_|)key)-(?:id)-([a-z0-9]{8})-expected_result1] PASSED [ 85%]
tests/plugins/box_test.py::TestBoxDetector::test_find_other_factor["privateKey": "-----BEGIN ENCRYPTED PRIVATE KEY----- key -----END ENCRYPTED PRIVATE KEY-----\n"-(?:private)-(?:key)-(-----BEGIN ENCRYPTED PRIVATE KEY-----(?:.|\\n)+-----END ENCRYPTED PRIVATE KEY-----(?:\\n|))-expected_result2] PASSED [ 90%]
tests/plugins/box_test.py::TestBoxDetector::test_find_other_factor["passphrase": "abcd1234abcd1234abcd1234abcd1234"-(?:pass)-(?:phrase)-([a-z0-9]{32})-expected_result3] PASSED [ 95%]
tests/plugins/box_test.py::TestBoxDetector::test_find_other_factor["enterpriseID": "1234"-(?:enterprise)-(?:id)-([0-9]+)-expected_result4] PASSED [100%]
```